### PR TITLE
Reverse inventory when loaded

### DIFF
--- a/app/inventory.js
+++ b/app/inventory.js
@@ -52,6 +52,8 @@ function getInventory(steamid64, callback) {
             return;
         }
 
+        inventory.reverse();
+
         if (own) save(inventory);
         callback(null, inventory);
     }]);


### PR DESCRIPTION
This will make the bot pick items that are in the back of the inventory, instead of the first items.