### PR TITLE
Alert when trade screenshot was not successful

### DIFF
--- a/app/trade.js
+++ b/app/trade.js
@@ -1070,6 +1070,7 @@ function receivedOfferChanged (offer, oldState) {
         removeItemsInTrade(offer.itemsToGive);
         Screenshot.receivedOfferChanged(offer.id, function (err, id) {
             if (err) {
+                Automatic.alert('trade', 'Recieved offer #' + offer.id + '(' + offer.partner.getSteamID64()') is now marked as ' + TradeOfferManager.ETradeOfferState[offer.state].toLowerCase() + '.')
                 log.warn('Error when capturing and sending screenshot: ' + err.message);
                 log.debug(err.stack);
                 return;
@@ -1103,6 +1104,7 @@ function sentOfferChanged (offer, oldState) {
         removeItemsInTrade(offer.itemsToGive);
         Screenshot.sentOfferChanged(offer.id, function (err, id) {
             if (err) {
+                Automatic.alert('trade', 'Sent offer #' + offer.id + '(' + offer.partner.getSteamID64()') is now marked as ' + TradeOfferManager.ETradeOfferState[offer.state].toLowerCase() + '.')
                 log.warn('Error when capturing and sending screenshot: ' + err.message);
                 log.debug(err.stack);
                 return;


### PR DESCRIPTION
Now the bot will message the owner when the trade couldn't screenshot, before it didn't alert