### PR TITLE
Added rate command and made bot always value keys using sell price

### DIFF
--- a/app/handler/commands.js
+++ b/app/handler/commands.js
@@ -256,13 +256,18 @@ exports.handleMessage = function (steamID, message) {
     log.info('Message from ' + friend.player_name + ' (' + steamID64 + '): ' + message);
 
     if (command === 'help') {
-        let reply = 'Here\'s a list of all my commands: !help, !how2trade, !price [amount] <name>, !stock, !buy [amount] <name>, !sell [amount] <name>';
+        let reply = 'Here\'s a list of all my commands: !help, !how2trade, !rate, !price [amount] <name>, !stock, !buy [amount] <name>, !sell [amount] <name>';
         if (isAdmin) {
             reply += ', !get, !add, !remove, !update, !restart, !stop';
         }
         client.chatMessage(steamID, reply);
     } else if (command === 'how2trade') {
         client.chatMessage(steamID, 'Send me a trade offer with the items you want to buy / sell.');
+    } else if (command === 'rate') {
+        const keyPrice = prices.getKeyPrice();
+        const keyPriceString = keyPrice.toString();
+
+        client.chatMessage(steamID, 'I value Mann Co. Supply Crate Keys at ' + keyPriceString + '. This means that one key is the same as ' + keyPriceString + ', and ' + keyPriceString + ' is the same as one key.');
     } else if (command === 'price') {
         const info = getItemAndAmount(steamID, message.substring(command.length + 1).trim());
 
@@ -278,7 +283,7 @@ exports.handleMessage = function (steamID, message) {
         const isBuying = match.intent === 0 || match.intent === 2;
         const isSelling = match.intent === 1 || match.intent === 2;
 
-        const keyPrices = prices.getKeyPrices();
+        const keyPrice = prices.getKeyPrice();
 
         const isKey = match.sku === '5021;6';
 
@@ -292,13 +297,13 @@ exports.handleMessage = function (steamID, message) {
             }
 
             // If the amount is 1, then don't convert to value and then to currencies. If it is for keys, then don't use conversion rate
-            const currencies = amount === 1 ? match.buy : Currencies.toCurrencies(match.buy.toValue(keyPrices.buy.metal) * amount, isKey ? undefined : keyPrices.buy.metal);
+            const currencies = amount === 1 ? match.buy : Currencies.toCurrencies(match.buy.toValue(keyPrice.metal) * amount, isKey ? undefined : keyPrice.metal);
 
             reply += pluralize(match.name, amount) + ' for ' + currencies.toString();
         }
 
         if (isSelling) {
-            const currencies = amount === 1 ? match.sell : Currencies.toCurrencies(match.sell.toValue(keyPrices.sell.metal) * amount, isKey ? undefined : keyPrices.sell.metal);
+            const currencies = amount === 1 ? match.sell : Currencies.toCurrencies(match.sell.toValue(keyPrice.metal) * amount, isKey ? undefined : keyPrice.metal);
 
             if (reply === '') {
                 reply = 'I am selling ';

--- a/app/handler/trades.js
+++ b/app/handler/trades.js
@@ -630,7 +630,9 @@ exports.newOffer = function (offer, done) {
 
                 // TODO: Go through all assetids and check if the item is being sold for a specific price
 
-                if (match !== null) {
+                if (match !== null && (sku !== '5021;6' || !exchange.contains.items)) {
+                    // If we found a matching price and the item is not a key, or the we are not trading items (meaning that we are trading keys) then add the price of the item
+
                     // Add value of items
                     exchange[which].value += match[intentString].toValue(keyPrice.metal) * amount;
                     exchange[which].keys += match[intentString].keys * amount;
@@ -640,15 +642,10 @@ exports.newOffer = function (offer, done) {
                         buy: match.buy,
                         sell: match.sell
                     };
-                }
-
-                if (sku === '5021;6') {
-                    // Offer contains keys
-                    if (match === null) {
-                        // We are not trading keys, add value anyway
-                        exchange[which].value += keyPrice.toValue() * amount;
-                        exchange[which].keys += amount;
-                    }
+                } else if (sku === '5021;6' && exchange.contains.items) {
+                    // Offer contains keys and we are not trading keys, add key value
+                    exchange[which].value += keyPrice.toValue() * amount;
+                    exchange[which].keys += amount;
                 } else if (match === null || match.intent === buying ? 1 : 0) {
                     // Offer contains an item that we are not trading
                     return done('decline', 'INVALID_ITEMS');

--- a/app/prices.js
+++ b/app/prices.js
@@ -96,7 +96,7 @@ exports.init = function (callback) {
  * @return {Number}
  */
 exports.amountCanAfford = function (buying, useKeys, currencies, currenciesDict) {
-    const keyPrice = exports.getKeyPrices()[buying ? 'buy' : 'sell'];
+    const keyPrice = exports.getKeyPrice();
 
     const value = currencies.toValue(keyPrice.metal);
 
@@ -147,8 +147,8 @@ exports.getPricelist = function () {
     return pricelist;
 };
 
-exports.getKeyPrices = function () {
-    return keyPrices;
+exports.getKeyPrice = function () {
+    return keyPrices.sell;
 };
 
 function handlePriceChange (data) {
@@ -272,12 +272,12 @@ exports.add = function (sku, data, callback) {
             return callback(new Error(errors.join(', ')));
         }
 
-        const keyPrice = exports.getKeyPrices()['sell'].metal;
+        const keyPrice = exports.getKeyPrice();
 
         const buy = new Currencies(entry.buy);
         const sell = new Currencies(entry.sell);
 
-        if (buy.toValue(keyPrice) >= sell.toValue(keyPrice)) {
+        if (buy.toValue(keyPrice.metal) >= sell.toValue(keyPrice.metal)) {
             return callback(new Error('Sell must be higher than buy'));
         }
 
@@ -371,12 +371,12 @@ exports.update = function (sku, data, callback) {
     copy.time = time;
 
     if (copy.autoprice === false) {
-        const keyPrice = exports.getKeyPrices()['sell'].metal;
+        const keyPrice = exports.getKeyPrice();
 
         const buy = new Currencies(copy.buy);
         const sell = new Currencies(copy.sell);
 
-        if (buy.toValue(keyPrice) >= sell.toValue(keyPrice)) {
+        if (buy.toValue(keyPrice.metal) >= sell.toValue(keyPrice.metal)) {
             return callback(new Error('Sell must be higher than buy'));
         }
 


### PR DESCRIPTION
- Removed function `getKeyPrices` and replaced it with `getKeyPrice` inside `app/prices.js`
  - The bot will use the sell price for keys as their value
- Save only key price in polldata instead of both buy and sell for keys
- Added rate command used to see what the bot values keys at