### PR TITLE
fixed using wrong schema function for unusuals

### DIFF
--- a/app/handler/commands.js
+++ b/app/handler/commands.js
@@ -164,10 +164,10 @@ function getItemFromParams (steamID, params) {
     }
 
     if (item.effect !== null) {
-        const effect = schemaManager.schema.getEffectByName(item.effect);
+        const effect = schemaManager.schema.getEffectIdByName(item.effect);
 
         if (effect === null) {
-            client.chatMessage(steamID, 'Could not find an unusual effect in the schema with the name "' + item.paintkit + '"');
+            client.chatMessage(steamID, 'Could not find an unusual effect in the schema with the name "' + item.effect + '"');
             return null;
         }
 


### PR DESCRIPTION
And changed item.paintkit to item.effect, would respond with "null" otherwise.
#239 