### PR TITLE
Fight typescripts empty array inference

### DIFF
--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -19,6 +19,7 @@ import { UnknownDictionaryKnownValues } from '../types/common';
 import { fixItem } from '../lib/items';
 import validator from '../lib/validator';
 import log from '../lib/logger';
+import SchemaManager from 'tf2-schema';
 
 const COMMANDS: string[] = [
     '!help - Get list of commands',
@@ -276,7 +277,7 @@ export = class Commands {
 
         const parsed = pure.concat(items);
 
-        const stock = [];
+        const stock: string[] = [];
         let left = 0;
 
         for (let i = 0; i < parsed.length; i++) {
@@ -1267,7 +1268,7 @@ export = class Commands {
         };
     }
 
-    private getItemFromParams(steamID: SteamID | string, params: UnknownDictionaryKnownValues): Item {
+    private getItemFromParams(steamID: SteamID | string, params: UnknownDictionaryKnownValues): Item | null {
         const item = SKU.fromString('');
 
         delete item.paint;
@@ -1279,7 +1280,7 @@ export = class Commands {
             foundSomething = true;
             // Look for all items that have the same name
 
-            const match = [];
+            const match: SchemaManager.SchemaItem[] = [];
 
             for (let i = 0; i < this.bot.schema.raw.schema.items.length; i++) {
                 const schemaItem = this.bot.schema.raw.schema.items[i];
@@ -1412,7 +1413,7 @@ export = class Commands {
         } else if (item.output !== null) {
             // Look for all items that have the same name
 
-            const match = [];
+            const match: SchemaManager.SchemaItem[] = [];
 
             for (let i = 0; i < this.bot.schema.raw.schema.items.length; i++) {
                 const schemaItem = this.bot.schema.raw.schema.items[i];

--- a/src/classes/Inventory.ts
+++ b/src/classes/Inventory.ts
@@ -136,7 +136,7 @@ export = class Inventory {
 
         if (tradableOnly) {
             // Copies the array
-            return [].concat(tradable);
+            return tradable.slice(0);
         }
 
         const nonTradable = this.nonTradable[sku] || [];

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -762,7 +762,7 @@ export = class MyHandler extends Handler {
             }
 
             // Convert object into an array so it can be sorted
-            const tradesWithPeople = [];
+            const tradesWithPeople: { steamID: string; trades: number }[] = [];
 
             for (const steamID in friendsWithTrades) {
                 if (!Object.prototype.hasOwnProperty.call(friendsWithTrades, steamID)) {

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -122,7 +122,7 @@ export default class Pricelist extends EventEmitter {
     }
 
     getPrices(): Entry[] {
-        return [].concat(this.prices);
+        return this.prices.slice(0);
     }
 
     hasPrice(sku: string, onlyEnabled = false): boolean {
@@ -159,7 +159,7 @@ export default class Pricelist extends EventEmitter {
     searchByName(search: string, enabledOnly = true): Entry | string[] | null {
         search = search.toLowerCase();
 
-        const match = [];
+        const match: Entry[] = [];
 
         for (let i = 0; i < this.prices.length; i++) {
             const entry = this.prices[i];

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -783,7 +783,7 @@ export = class Trades {
             return false;
         }
 
-        const copy = b.concat();
+        const copy = b.slice(0);
 
         for (let i = 0; i < a.length; i++) {
             // Find index of matching item

--- a/src/lib/extend/item/getSKU.ts
+++ b/src/lib/extend/item/getSKU.ts
@@ -159,13 +159,13 @@ function getWear(item: EconItem): number {
  * Get skin from item
  * @param item - Item object
  */
-function getPaintKit(item: EconItem, schema: SchemaManager.Schema): number {
+function getPaintKit(item: EconItem, schema: SchemaManager.Schema): number | null {
     if (getWear(item) === null) {
         return null;
     }
 
     let hasCaseCollection = false;
-    let skin = null;
+    let skin: string | null = null;
 
     for (let i = 0; i < item.descriptions.length; i++) {
         const description = item.descriptions[i].value;
@@ -185,7 +185,7 @@ function getPaintKit(item: EconItem, schema: SchemaManager.Schema): number {
         return null;
     }
 
-    if (skin.indexOf('Mk.I') !== -1) {
+    if (skin.includes('Mk.I')) {
         return schema.getSkinIdByName(skin);
     }
 


### PR DESCRIPTION
It sometimes thinks your want `never[]`.
This type is an array that has zero elements.
However, it sometimes doesn't understand that this array is nolonger empty.
Also replaced [].concat(toBeCopied) with toBeCopied.slice(0).