### PR TITLE
Fixed !trades shows wrong value.

### DIFF
--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -1153,8 +1153,7 @@ export = class Commands {
     }
 
     private tradesCommand(steamID: SteamID): void {
-        const now = moment();
-        const aDayAgo = moment().subtract(24, 'day');
+        const aDayAgo = moment().subtract(24, 'hour');
         const startOfDay = moment().startOf('day');
 
         let tradesToday = 0;
@@ -1177,7 +1176,7 @@ export = class Commands {
                     trades24Hours++;
                 }
 
-                if (offerData[offerID].finishTimestamp >= now.valueOf() - startOfDay.valueOf()) {
+                if (offerData[offerID].finishTimestamp >= startOfDay.valueOf()) {
                     // All trades since 0:00 in the morning.
                     tradesToday++;
                 }


### PR DESCRIPTION
Change `const aDayAgo = ...subtract(24, 'day')` to `...subtract(24, 'hour')`, because if 'day' is used, it substract 24 days from now.

The original coding subtracts `now` and `startOfDay`, which make it count all the successful trades (tradesTotal) because the value from the subtraction was less than `startOfDay` value.

Let say, the values are as below:
`now` = 1582725841
`startOfDay` = 1582675200
`now - startOfDay` = 50641
`offerData[offerID].finishTimestamp >= 50641` ---> count all `offerID` with `isAccepted = true` from timestamp 50641 until the highest timestamp found in polldata file.

But if no subtraction:
`offerData[offerID].finishTimestamp >= 1582675200` ---> count all offerID with `isAccepted = true` from timestamp 1582675200 until the highest timestamp found in polldata file.