### PR TITLE
Dupe checks 🔥

### DIFF
--- a/ecosystem.template.json
+++ b/ecosystem.template.json
@@ -25,6 +25,9 @@
                 "BPTF_DETAILS_SELL": "I am selling my %name% for %price%, I am selling %amount_trade%.",
                 "OFFER_MESSAGE": "",
 
+                "ENABLE_DUPE_CHECK": true,
+                "DECLINE_DUPES": false,
+                "MINIMUM_KEYS_DUPE_CHECK": 10,
                 "ENABLE_MANUAL_REVIEW": true,
                 "AUTOBUMP": true,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -391,6 +391,15 @@
             "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
             "dev": true
         },
+        "@types/cheerio": {
+            "version": "0.22.17",
+            "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.17.tgz",
+            "integrity": "sha512-izlm+hbqWN9csuB9GSMfCnAyd3/57XZi3rfz1B0C4QBGVMp+9xQ7+9KYnep+ySfUrCWql4lGzkLf0XmprXcz9g==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/death": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@types/death/-/death-1.1.0.tgz",
@@ -980,26 +989,16 @@
             "integrity": "sha1-BsIe7RobBq62dVPNxT4jJ0usIpY="
         },
         "cheerio": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-            "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+            "version": "1.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+            "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
             "requires": {
                 "css-select": "~1.2.0",
-                "dom-serializer": "~0.1.0",
+                "dom-serializer": "~0.1.1",
                 "entities": "~1.1.1",
                 "htmlparser2": "^3.9.1",
-                "lodash.assignin": "^4.0.9",
-                "lodash.bind": "^4.1.4",
-                "lodash.defaults": "^4.0.1",
-                "lodash.filter": "^4.4.0",
-                "lodash.flatten": "^4.2.0",
-                "lodash.foreach": "^4.3.0",
-                "lodash.map": "^4.4.0",
-                "lodash.merge": "^4.4.0",
-                "lodash.pick": "^4.2.1",
-                "lodash.reduce": "^4.4.0",
-                "lodash.reject": "^4.4.0",
-                "lodash.some": "^4.4.0"
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
             }
         },
         "chokidar": {
@@ -4126,6 +4125,29 @@
                     "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
                     "requires": {
                         "lodash": "^4.17.14"
+                    }
+                },
+                "cheerio": {
+                    "version": "0.22.0",
+                    "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+                    "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+                    "requires": {
+                        "css-select": "~1.2.0",
+                        "dom-serializer": "~0.1.0",
+                        "entities": "~1.1.1",
+                        "htmlparser2": "^3.9.1",
+                        "lodash.assignin": "^4.0.9",
+                        "lodash.bind": "^4.1.4",
+                        "lodash.defaults": "^4.0.1",
+                        "lodash.filter": "^4.4.0",
+                        "lodash.flatten": "^4.2.0",
+                        "lodash.foreach": "^4.3.0",
+                        "lodash.map": "^4.4.0",
+                        "lodash.merge": "^4.4.0",
+                        "lodash.pick": "^4.2.1",
+                        "lodash.reduce": "^4.4.0",
+                        "lodash.reject": "^4.4.0",
+                        "lodash.some": "^4.4.0"
                     }
                 },
                 "steam-totp": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "bptf-listings": "^4.5.0",
         "bptf-login": "^1.0.3",
         "callback-queue": "^3.0.0",
+        "cheerio": "^1.0.0-rc.3",
         "death": "^1.1.0",
         "dot-prop": "^5.2.0",
         "dotenv": "^8.2.0",
@@ -59,6 +60,7 @@
     "devDependencies": {
         "@types/async": "^3.2.0",
         "@types/bluebird-global": "^3.5.12",
+        "@types/cheerio": "^0.22.17",
         "@types/death": "^1.1.0",
         "@types/graceful-fs": "^4.1.3",
         "@types/pluralize": "0.0.29",

--- a/src/classes/CartQueue.ts
+++ b/src/classes/CartQueue.ts
@@ -90,7 +90,7 @@ class CartQueue {
 
         log.debug('Constructing offer');
 
-        cart.constructOffer()
+        Promise.resolve(cart.constructOffer())
             .then(alteredMessage => {
                 log.debug('Constructed offer');
                 if (alteredMessage) {

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -1385,14 +1385,6 @@ export = class Commands {
     }
 
     private tradesCommand(steamID: SteamID): void {
-        if (process.env.ENABLE_MANUAL_REVIEW !== 'true') {
-            this.bot.sendMessage(
-                steamID,
-                'Manual review is disabled, enable it by setting `ENABLE_MANUAL_REVIEW` to true'
-            );
-            return;
-        }
-
         // Go through polldata and find active offers
 
         const pollData = this.bot.manager.pollData;
@@ -1448,7 +1440,7 @@ export = class Commands {
     private tradeCommand(steamID: SteamID, message: string): void {
         const offerId = CommandParser.removeCommand(message).trim();
 
-        if (!offerId) {
+        if (offerId === '') {
             this.bot.sendMessage(steamID, 'Missing offer id. Example: "!trade 1234"');
             return;
         }
@@ -1468,7 +1460,7 @@ export = class Commands {
 
         const offerData = this.bot.manager.pollData.offerData[offerId];
 
-        if (offerData?.action.action !== 'skip') {
+        if (offerData?.action?.action !== 'skip') {
             this.bot.sendMessage(steamID, "Offer can't be reviewed.");
             return;
         }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -99,6 +99,14 @@ export = class MyHandler extends Handler {
         }, 1000);
     }
 
+    hasDupeCheckEnabled(): boolean {
+        return this.dupeCheckEnabled;
+    }
+
+    getMinimumKeysDupeCheck(): number {
+        return this.minimumKeysDupeCheck;
+    }
+
     onRun(): Promise<{
         loginAttempts?: number[];
         pricelist?: EntryData[];

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -663,7 +663,7 @@ export = class MyHandler extends Handler {
                     async.series(requests, callback);
                 });
 
-                log.debug('Got result from dupe checks');
+                log.debug('Got result from dupe checks', { result: result });
 
                 // Decline by default
                 const declineDupes = process.env.DECLINE_DUPES !== 'false';

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -452,7 +452,7 @@ export = class MyHandler extends Handler {
 
                         if (
                             item.effect !== null &&
-                            match.buy.toValue() > this.minimumKeysDupeCheck * keyPrice.toValue()
+                            match.buy.toValue(keyPrice.metal) > this.minimumKeysDupeCheck * keyPrice.toValue()
                         ) {
                             assetidsToCheck = assetidsToCheck.concat(assetids);
                         }

--- a/src/classes/TF2Inventory.ts
+++ b/src/classes/TF2Inventory.ts
@@ -1,0 +1,172 @@
+import SteamID from 'steamid';
+import TradeOfferManager from 'steam-tradeoffer-manager';
+import request from '@nicklason/request-retry';
+import cheerio from 'cheerio';
+
+type TF2Attribute = {
+    defindex: number;
+    value: number | string;
+    float_value?: number;
+};
+
+type TF2Item = {
+    id: number;
+
+    original_id: number;
+
+    defindex: number;
+
+    level: number;
+
+    quality: number;
+
+    inventory: number;
+
+    quantity: number;
+
+    origin: number;
+
+    style?: number | undefined;
+
+    flag_cannot_trade?: boolean;
+
+    flag_cannot_craft?: boolean;
+
+    attributes?: TF2Attribute[];
+};
+
+export = class TF2Inventory {
+    private readonly steamID: SteamID;
+
+    private readonly manager: TradeOfferManager;
+
+    private items: TF2Item[] = [];
+
+    private slots: number = null;
+
+    constructor(steamID: SteamID | string, manager: TradeOfferManager) {
+        this.steamID = new SteamID(steamID.toString());
+        this.manager = manager;
+    }
+
+    getSteamID(): SteamID {
+        return this.steamID;
+    }
+
+    getItems(): TF2Item[] {
+        return this.items;
+    }
+
+    getSlots(): number {
+        return this.slots;
+    }
+
+    async isDuped(assetid: string): Promise<boolean | null> {
+        // Check if the item exists on backpack.tf and if it is duped
+        const history = await TF2Inventory.getItemHistory(assetid);
+
+        if (history.recorded === true) {
+            return history.isDuped;
+        }
+
+        // Inventory is not updated on bptf, get the original id
+
+        // Fetch inventory using TF2 GetPlayerItems API if we haven't already
+        if (this.getItems().length === 0) {
+            await this.fetch();
+        }
+
+        // Find item in the inventory
+        const item = this.getItems().find(item => item.id.toString() == assetid);
+
+        if (item === undefined) {
+            // Could not find the item in the inventory, failed to check if the item is duped
+            throw new Error('Could not find item in inventory');
+        }
+
+        // Get history using original id
+        const historyFromOriginal = await TF2Inventory.getItemHistory(item.original_id.toString());
+
+        if (historyFromOriginal.recorded === true) {
+            return history.isDuped;
+        }
+
+        // Item has never been seen on backpack.tf before
+        // throw new Error('No history for given item');
+
+        return null;
+    }
+
+    fetch(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            request(
+                {
+                    url: 'https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/',
+                    method: 'GET',
+                    qs: {
+                        key: this.manager.apiKey,
+                        steamid: this.getSteamID().toString()
+                    },
+                    json: true,
+                    gzip: true
+                },
+                (err, response, body) => {
+                    if (err) {
+                        return reject(err);
+                    }
+
+                    if (body.result.status != 1) {
+                        err = new Error(body.result.statusDetail);
+                        err.status = body.result.status;
+                        return reject(err);
+                    }
+
+                    this.slots = body.result.num_backpack_slots;
+                    this.items = body.result.items;
+
+                    return resolve();
+                }
+            );
+        });
+    }
+
+    static getItemHistory(
+        assetid: string
+    ): Promise<{
+        recorded: boolean;
+        isDuped?: boolean;
+        history?: [];
+    }> {
+        return new Promise((resolve, reject) => {
+            request(
+                {
+                    url: 'https://backpack.tf/item/' + assetid,
+                    method: 'GET'
+                },
+                function(err, response, body) {
+                    if (err) {
+                        return reject(err);
+                    }
+
+                    const $ = cheerio.load(body);
+
+                    if ($('table').length !== 1) {
+                        return resolve({
+                            recorded: false
+                        });
+                    }
+
+                    // TODO: Make a list that contains the item history
+
+                    const isDuped = $('dupe-modal-btn').length > 0;
+
+                    return resolve({
+                        recorded: true,
+                        isDuped: isDuped,
+                        history: []
+                    });
+                }
+            );
+        });
+    }
+};

--- a/src/classes/TF2Inventory.ts
+++ b/src/classes/TF2Inventory.ts
@@ -158,7 +158,7 @@ export = class TF2Inventory {
 
                     // TODO: Make a list that contains the item history
 
-                    const isDuped = $('dupe-modal-btn').length > 0;
+                    const isDuped = $('#dupe-modal-btn').length > 0;
 
                     return resolve({
                         recorded: true,

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -262,7 +262,7 @@ export = class Trades {
 
         offer.data('handleTimestamp', start);
 
-        this.bot.handler.onNewTradeOffer(offer).asCallback((err, response) => {
+        Promise.resolve(this.bot.handler.onNewTradeOffer(offer)).asCallback((err, response) => {
             if (err) {
                 log.debug('Error occurred while handler was processing offer: ', err);
                 throw err;

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -279,6 +279,10 @@ export = class Trades {
                 response: response
             });
 
+            if (!response) {
+                return this.finishProcessingOffer(offer.id);
+            }
+
             this.applyActionToOffer(response.action, response.reason, response.meta || {}, offer).finally(() => {
                 this.finishProcessingOffer(offer.id);
             });

--- a/src/classes/UserCart.ts
+++ b/src/classes/UserCart.ts
@@ -57,7 +57,7 @@ class UserCart extends Cart {
                     async.series(requests, callback);
                 });
 
-                log.debug('Got result from dupe checks');
+                log.debug('Got result from dupe checks', { result: result });
 
                 for (let i = 0; i < result.length; i++) {
                     if (result[i] === true) {

--- a/template.env
+++ b/template.env
@@ -13,6 +13,9 @@ BPTF_DETAILS_BUY="I am buying your %name% for %price%, I have %current_stock% / 
 BPTF_DETAILS_SELL="I am selling my %name% for %price%, I am selling %amount_trade%."
 OFFER_MESSAGE=""
 
+ENABLE_DUPE_CHECK=true
+DECLINE_DUPES=false
+MINIMUM_KEYS_DUPE_CHECK=10
 ENABLE_MANUAL_REVIEW=true
 AUTOBUMP=true
 


### PR DESCRIPTION
Adds dupe checks to the bot.

- Enable dupe checks by setting `ENABLE_DUPE_CHECK` to `true`. Default is `false`.
- Minimum price for dupe check can be setting `MINIMUM_KEYS_DUPE_CHECK` to any amount in keys, both whole numbers and decimals. Default is `0`.
- Decline offers that contain any duped items by setting `DECLINE_DUPES` to `true`. Default is `false`.
- If a dupe check fails then for received offers the offer will be skipped and a notification will be sent to the admins for them to review the offer, for sending offers the bot will stop and say that it failed to check for dupes.

If the bot fails to make a dupe check when creating an offer then the bot should tell the user to try and send an offer instead, that way an admin will be able to review the offer and accept / decline it.

How dupe checks work:

1. The bot attempts to get the history page of an item on backpack.tf. It will use the current assetid that the item has. If it fails then the dupe check will fail.
2. If backpack.tf knows about the item using the current assetid then the dupe check is done and the result will depend on if backpack.tf says it is duped or not.
3. If backpack.tf does not know about the item, then the bot will load the inventory using the TF2 GetPlayerItems API that backpack.tf also used to load inventories. The bot will load the inventory and find the original id. If the API does not give a good response, or the item could not be found in the inventory, then the dupe check fails.
4. The bot now has the original id and can then try and get the item history from backpack.tf using that. If it fails then we can conclude that backpack.tf doesn't know about the item, meaning that we don't know if the item is duped or not. The dupe check will fail. If backpack.tf does know about the item, then the dupe check is done.