### PR TITLE
Merge development with master

### DIFF
--- a/ecosystem.template.json
+++ b/ecosystem.template.json
@@ -25,6 +25,9 @@
                 "BPTF_DETAILS_SELL": "I am selling my %name% for %price%, I am selling %amount_trade%.",
                 "OFFER_MESSAGE": "",
 
+                "ENABLE_DUPE_CHECK": true,
+                "DECLINE_DUPES": false,
+                "MINIMUM_KEYS_DUPE_CHECK": 10,
                 "ENABLE_MANUAL_REVIEW": true,
                 "AUTOBUMP": true,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -391,6 +391,15 @@
             "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
             "dev": true
         },
+        "@types/cheerio": {
+            "version": "0.22.17",
+            "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.17.tgz",
+            "integrity": "sha512-izlm+hbqWN9csuB9GSMfCnAyd3/57XZi3rfz1B0C4QBGVMp+9xQ7+9KYnep+ySfUrCWql4lGzkLf0XmprXcz9g==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/death": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@types/death/-/death-1.1.0.tgz",
@@ -980,26 +989,16 @@
             "integrity": "sha1-BsIe7RobBq62dVPNxT4jJ0usIpY="
         },
         "cheerio": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-            "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+            "version": "1.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+            "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
             "requires": {
                 "css-select": "~1.2.0",
-                "dom-serializer": "~0.1.0",
+                "dom-serializer": "~0.1.1",
                 "entities": "~1.1.1",
                 "htmlparser2": "^3.9.1",
-                "lodash.assignin": "^4.0.9",
-                "lodash.bind": "^4.1.4",
-                "lodash.defaults": "^4.0.1",
-                "lodash.filter": "^4.4.0",
-                "lodash.flatten": "^4.2.0",
-                "lodash.foreach": "^4.3.0",
-                "lodash.map": "^4.4.0",
-                "lodash.merge": "^4.4.0",
-                "lodash.pick": "^4.2.1",
-                "lodash.reduce": "^4.4.0",
-                "lodash.reject": "^4.4.0",
-                "lodash.some": "^4.4.0"
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
             }
         },
         "chokidar": {
@@ -4126,6 +4125,29 @@
                     "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
                     "requires": {
                         "lodash": "^4.17.14"
+                    }
+                },
+                "cheerio": {
+                    "version": "0.22.0",
+                    "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+                    "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+                    "requires": {
+                        "css-select": "~1.2.0",
+                        "dom-serializer": "~0.1.0",
+                        "entities": "~1.1.1",
+                        "htmlparser2": "^3.9.1",
+                        "lodash.assignin": "^4.0.9",
+                        "lodash.bind": "^4.1.4",
+                        "lodash.defaults": "^4.0.1",
+                        "lodash.filter": "^4.4.0",
+                        "lodash.flatten": "^4.2.0",
+                        "lodash.foreach": "^4.3.0",
+                        "lodash.map": "^4.4.0",
+                        "lodash.merge": "^4.4.0",
+                        "lodash.pick": "^4.2.1",
+                        "lodash.reduce": "^4.4.0",
+                        "lodash.reject": "^4.4.0",
+                        "lodash.some": "^4.4.0"
                     }
                 },
                 "steam-totp": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "bptf-listings": "^4.5.0",
         "bptf-login": "^1.0.3",
         "callback-queue": "^3.0.0",
+        "cheerio": "^1.0.0-rc.3",
         "death": "^1.1.0",
         "dot-prop": "^5.2.0",
         "dotenv": "^8.2.0",
@@ -59,6 +60,7 @@
     "devDependencies": {
         "@types/async": "^3.2.0",
         "@types/bluebird-global": "^3.5.12",
+        "@types/cheerio": "^0.22.17",
         "@types/death": "^1.1.0",
         "@types/graceful-fs": "^4.1.3",
         "@types/pluralize": "0.0.29",

--- a/src/classes/Bot.ts
+++ b/src/classes/Bot.ts
@@ -427,10 +427,11 @@ export = class Bot {
                                     this.listingManager.init(callback);
                                 },
                                 (callback): void => {
-                                    log.debug('Updating profile settings...');
                                     if (process.env.SKIP_UPDATE_PROFILE_SETTINGS !== 'true') {
                                         return callback(null);
                                     }
+
+                                    log.debug('Updating profile settings...');
 
                                     this.community.profileSettings(
                                         {

--- a/src/classes/CartQueue.ts
+++ b/src/classes/CartQueue.ts
@@ -90,7 +90,7 @@ class CartQueue {
 
         log.debug('Constructing offer');
 
-        cart.constructOffer()
+        Promise.resolve(cart.constructOffer())
             .then(alteredMessage => {
                 log.debug('Constructed offer');
                 if (alteredMessage) {

--- a/src/classes/Commands.ts
+++ b/src/classes/Commands.ts
@@ -1385,14 +1385,6 @@ export = class Commands {
     }
 
     private tradesCommand(steamID: SteamID): void {
-        if (process.env.ENABLE_MANUAL_REVIEW !== 'true') {
-            this.bot.sendMessage(
-                steamID,
-                'Manual review is disabled, enable it by setting `ENABLE_MANUAL_REVIEW` to true'
-            );
-            return;
-        }
-
         // Go through polldata and find active offers
 
         const pollData = this.bot.manager.pollData;
@@ -1448,7 +1440,7 @@ export = class Commands {
     private tradeCommand(steamID: SteamID, message: string): void {
         const offerId = CommandParser.removeCommand(message).trim();
 
-        if (!offerId) {
+        if (offerId === '') {
             this.bot.sendMessage(steamID, 'Missing offer id. Example: "!trade 1234"');
             return;
         }
@@ -1468,7 +1460,7 @@ export = class Commands {
 
         const offerData = this.bot.manager.pollData.offerData[offerId];
 
-        if (offerData?.action.action !== 'skip') {
+        if (offerData?.action?.action !== 'skip') {
             this.bot.sendMessage(steamID, "Offer can't be reviewed.");
             return;
         }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -11,11 +11,14 @@ import TradeOfferManager, { TradeOffer, PollData } from 'steam-tradeoffer-manage
 import pluralize from 'pluralize';
 import SteamID from 'steamid';
 import Currencies from 'tf2-currencies';
+import SKU from 'tf2-sku';
+import async from 'async';
 
 import log from '../lib/logger';
 import * as files from '../lib/files';
 import paths from '../resources/paths';
 import { parseJSON, exponentialBackoff } from '../lib/helpers';
+import TF2Inventory from './TF2Inventory';
 
 export = class MyHandler extends Handler {
     private readonly commands: Commands;
@@ -31,6 +34,10 @@ export = class MyHandler extends Handler {
     private minimumReclaimed = 9;
 
     private combineThreshold = 9;
+
+    private dupeCheckEnabled = false;
+
+    private minimumKeysDupeCheck = 0;
 
     recentlySentMessage: UnknownDictionary<number> = {};
 
@@ -54,6 +61,15 @@ export = class MyHandler extends Handler {
 
         if (!isNaN(combineThreshold)) {
             this.combineThreshold = combineThreshold;
+        }
+
+        if (process.env.ENABLE_DUPE_CHECK === 'true') {
+            this.dupeCheckEnabled = true;
+        }
+
+        const minimumKeysDupeCheck = parseInt(process.env.MINIMUM_KEYS_DUPE_CHECK);
+        if (!isNaN(minimumKeysDupeCheck)) {
+            this.minimumKeysDupeCheck = minimumKeysDupeCheck;
         }
 
         const groups = parseJSON(process.env.GROUPS);
@@ -81,6 +97,14 @@ export = class MyHandler extends Handler {
         setInterval(() => {
             this.recentlySentMessage = {};
         }, 1000);
+    }
+
+    hasDupeCheckEnabled(): boolean {
+        return this.dupeCheckEnabled;
+    }
+
+    getMinimumKeysDupeCheck(): number {
+        return this.minimumKeysDupeCheck;
     }
 
     onRun(): Promise<{
@@ -231,388 +255,471 @@ export = class MyHandler extends Handler {
         log.warn('Please add the backpack.tf API key and access token to the environment variables!', details);
     }
 
-    onNewTradeOffer(
+    async onNewTradeOffer(
         offer: TradeOffer
     ): Promise<null | {
         action: 'accept' | 'decline' | 'skip';
         reason: string;
         meta?: UnknownDictionary<any>;
     }> {
-        return new Promise(resolve => {
-            offer.log('info', 'is being processed...');
+        offer.log('info', 'is being processed...');
 
-            // Allow sending notifications
-            offer.data('notify', true);
+        // Allow sending notifications
+        offer.data('notify', true);
 
-            const ourItems = Inventory.fromItems(
-                this.bot.client.steamID,
-                offer.itemsToGive,
-                this.bot.manager,
-                this.bot.schema
-            );
+        const ourItems = Inventory.fromItems(
+            this.bot.client.steamID,
+            offer.itemsToGive,
+            this.bot.manager,
+            this.bot.schema
+        );
 
-            const theirItems = Inventory.fromItems(
-                offer.partner,
-                offer.itemsToReceive,
-                this.bot.manager,
-                this.bot.schema
-            );
+        const theirItems = Inventory.fromItems(offer.partner, offer.itemsToReceive, this.bot.manager, this.bot.schema);
 
-            const items = {
-                our: ourItems.getItems(),
-                their: theirItems.getItems()
-            };
+        const items = {
+            our: ourItems.getItems(),
+            their: theirItems.getItems()
+        };
 
-            const exchange = {
-                contains: { items: false, metal: false, keys: false },
-                our: { value: 0, keys: 0, scrap: 0, contains: { items: false, metal: false, keys: false } },
-                their: { value: 0, keys: 0, scrap: 0, contains: { items: false, metal: false, keys: false } }
-            };
+        const exchange = {
+            contains: { items: false, metal: false, keys: false },
+            our: { value: 0, keys: 0, scrap: 0, contains: { items: false, metal: false, keys: false } },
+            their: { value: 0, keys: 0, scrap: 0, contains: { items: false, metal: false, keys: false } }
+        };
 
-            const itemsDict = { our: {}, their: {} };
+        const itemsDict = { our: {}, their: {} };
 
-            const states = [false, true];
+        const states = [false, true];
 
-            let hasInvalidItems = false;
+        let hasInvalidItems = false;
 
-            for (let i = 0; i < states.length; i++) {
-                const buying = states[i];
-                const which = buying ? 'their' : 'our';
+        for (let i = 0; i < states.length; i++) {
+            const buying = states[i];
+            const which = buying ? 'their' : 'our';
 
-                for (const sku in items[which]) {
-                    if (!Object.prototype.hasOwnProperty.call(items[which], sku)) {
-                        continue;
-                    }
+            for (const sku in items[which]) {
+                if (!Object.prototype.hasOwnProperty.call(items[which], sku)) {
+                    continue;
+                }
 
-                    if (sku === 'unknown') {
-                        // Offer contains an item that is not from TF2
+                if (sku === 'unknown') {
+                    // Offer contains an item that is not from TF2
+                    hasInvalidItems = true;
+                }
+
+                if (sku === '5000;6') {
+                    exchange.contains.metal = true;
+                    exchange[which].contains.metal = true;
+                } else if (sku === '5001;6') {
+                    exchange.contains.metal = true;
+                    exchange[which].contains.metal = true;
+                } else if (sku === '5002;6') {
+                    exchange.contains.metal = true;
+                    exchange[which].contains.metal = true;
+                } else if (sku === '5021;6') {
+                    exchange.contains.keys = true;
+                    exchange[which].contains.keys = true;
+                } else {
+                    exchange.contains.items = true;
+                    exchange[which].contains.items = true;
+                }
+
+                const amount = items[which][sku].length;
+
+                itemsDict[which][sku] = amount;
+            }
+        }
+
+        offer.data('dict', itemsDict);
+
+        // Check if the offer is from an admin
+        if (this.bot.isAdmin(offer.partner)) {
+            offer.log('trade', 'is from an admin, accepting. Summary:\n' + offer.summarize(this.bot.schema));
+            return { action: 'accept', reason: 'ADMIN' };
+        }
+
+        if (hasInvalidItems) {
+            // Using boolean because items dict always needs to be saved
+            offer.log('info', 'contains items not from TF2, declining...');
+            return { action: 'decline', reason: 'INVALID_ITEMS' };
+        }
+
+        const itemsDiff = offer.getDiff();
+
+        if (offer.itemsToGive.length === 0 && ['donate', 'gift'].includes(offer.message.toLowerCase())) {
+            offer.log('trade', 'is a gift offer, accepting. Summary:\n' + offer.summarize(this.bot.schema));
+            return { action: 'accept', reason: 'GIFT' };
+        } else if (offer.itemsToReceive.length === 0 || offer.itemsToGive.length === 0) {
+            offer.log('info', 'is a gift offer, declining...');
+            return { action: 'decline', reason: 'GIFT' };
+        }
+
+        const manualReviewEnabled = process.env.ENABLE_MANUAL_REVIEW === 'true';
+
+        const itemPrices = {};
+
+        const keyPrice = this.bot.pricelist.getKeyPrice();
+
+        let hasOverstock = false;
+
+        // A list of things that is wrong about the offer and other information
+        const wrongAboutOffer: (
+            | {
+                  reason: 'OVERSTOCKED';
+                  sku: string;
+                  buying: boolean;
+                  diff: number;
+                  amountCanTrade: number;
+              }
+            | {
+                  reason: 'INVALID_ITEMS';
+                  sku: string;
+                  buying: boolean;
+                  amount: number;
+              }
+            | {
+                  reason: 'INVALID_VALUE';
+                  our: number;
+                  their: number;
+              }
+            | {
+                  reason: 'DUPE_CHECK_FAILED';
+                  assetid?: string;
+                  error?: string;
+              }
+            | {
+                  reason: 'DUPED_ITEMS';
+                  assetid: string;
+              }
+        )[] = [];
+
+        let assetidsToCheck = [];
+
+        for (let i = 0; i < states.length; i++) {
+            const buying = states[i];
+            const which = buying ? 'their' : 'our';
+            const intentString = buying ? 'buy' : 'sell';
+
+            for (const sku in items[which]) {
+                if (!Object.prototype.hasOwnProperty.call(items[which], sku)) {
+                    continue;
+                }
+
+                const assetids = items[which][sku];
+                const amount = assetids.length;
+
+                if (sku === '5000;6') {
+                    exchange[which].value += amount;
+                    exchange[which].scrap += amount;
+                } else if (sku === '5001;6') {
+                    const value = 3 * amount;
+                    exchange[which].value += value;
+                    exchange[which].scrap += value;
+                } else if (sku === '5002;6') {
+                    const value = 9 * amount;
+                    exchange[which].value += value;
+                    exchange[which].scrap += value;
+                } else {
+                    const match = this.bot.pricelist.getPrice(sku, true);
+
+                    // TODO: Go through all assetids and check if the item is being sold for a specific price
+
+                    if (match !== null && (sku !== '5021;6' || !exchange.contains.items)) {
+                        // If we found a matching price and the item is not a key, or the we are not trading items (meaning that we are trading keys) then add the price of the item
+
+                        // Add value of items
+                        exchange[which].value += match[intentString].toValue(keyPrice.metal) * amount;
+                        exchange[which].keys += match[intentString].keys * amount;
+                        exchange[which].scrap += Currencies.toScrap(match[intentString].metal) * amount;
+
+                        itemPrices[match.sku] = {
+                            buy: match.buy,
+                            sell: match.sell
+                        };
+
+                        // Check stock limits (not for keys)
+                        const diff = itemsDiff[sku];
+
+                        const buyingOverstockCheck = diff > 0;
+                        const amountCanTrade = this.bot.inventoryManager.amountCanTrade(sku, buyingOverstockCheck);
+
+                        if (diff !== 0 && amountCanTrade < diff) {
+                            // User is taking too many / offering too many
+                            hasOverstock = true;
+
+                            wrongAboutOffer.push({
+                                reason: 'OVERSTOCKED',
+                                sku: sku,
+                                buying: buyingOverstockCheck,
+                                diff: diff,
+                                amountCanTrade: amountCanTrade
+                            });
+                        }
+
+                        const item = SKU.fromString(sku);
+
+                        if (
+                            item.effect !== null &&
+                            match.buy.toValue(keyPrice.metal) > this.minimumKeysDupeCheck * keyPrice.toValue()
+                        ) {
+                            assetidsToCheck = assetidsToCheck.concat(assetids);
+                        }
+                    } else if (sku === '5021;6' && exchange.contains.items) {
+                        // Offer contains keys and we are not trading keys, add key value
+                        exchange[which].value += keyPrice.toValue() * amount;
+                        exchange[which].keys += amount;
+                    } else if (match === null || match.intent === (buying ? 1 : 0)) {
+                        // Offer contains an item that we are not trading
                         hasInvalidItems = true;
+
+                        wrongAboutOffer.push({
+                            reason: 'INVALID_ITEMS',
+                            sku: sku,
+                            buying: buying,
+                            amount: amount
+                        });
                     }
-
-                    if (sku === '5000;6') {
-                        exchange.contains.metal = true;
-                        exchange[which].contains.metal = true;
-                    } else if (sku === '5001;6') {
-                        exchange.contains.metal = true;
-                        exchange[which].contains.metal = true;
-                    } else if (sku === '5002;6') {
-                        exchange.contains.metal = true;
-                        exchange[which].contains.metal = true;
-                    } else if (sku === '5021;6') {
-                        exchange.contains.keys = true;
-                        exchange[which].contains.keys = true;
-                    } else {
-                        exchange.contains.items = true;
-                        exchange[which].contains.items = true;
-                    }
-
-                    const amount = items[which][sku].length;
-
-                    itemsDict[which][sku] = amount;
                 }
             }
+        }
 
-            offer.data('dict', itemsDict);
+        // Doing this so that the prices will always be displayed as only metal
+        exchange.our.scrap += exchange.our.keys * keyPrice.toValue();
+        exchange.our.keys = 0;
+        exchange.their.scrap += exchange.their.keys * keyPrice.toValue();
+        exchange.their.keys = 0;
 
-            // Check if the offer is from an admin
-            if (this.bot.isAdmin(offer.partner)) {
-                offer.log('trade', 'is from an admin, accepting. Summary:\n' + offer.summarize(this.bot.schema));
-                return resolve({ action: 'accept', reason: 'ADMIN' });
+        offer.data('value', {
+            our: {
+                total: exchange.our.value,
+                keys: exchange.our.keys,
+                metal: Currencies.toRefined(exchange.our.scrap)
+            },
+            their: {
+                total: exchange.their.value,
+                keys: exchange.their.keys,
+                metal: Currencies.toRefined(exchange.their.scrap)
+            },
+            rate: keyPrice.metal
+        });
+
+        offer.data('prices', itemPrices);
+
+        if (exchange.contains.metal && !exchange.contains.keys && !exchange.contains.items) {
+            // Offer only contains metal
+            offer.log('info', 'only contains metal, declining...');
+            return { action: 'decline', reason: 'ONLY_METAL' };
+        } else if (exchange.contains.keys && !exchange.contains.items) {
+            // Offer is for trading keys, check if we are trading them
+            const priceEntry = this.bot.pricelist.getPrice('5021;6', true);
+            if (priceEntry === null) {
+                // We are not trading keys
+                offer.log('info', 'we are not trading keys, declining...');
+                return { action: 'decline', reason: 'NOT_TRADING_KEYS' };
+            } else if (exchange.our.contains.keys && priceEntry.intent !== 1 && priceEntry.intent !== 2) {
+                // We are not selling keys
+                offer.log('info', 'we are not selling keys, declining...');
+                return { action: 'decline', reason: 'NOT_TRADING_KEYS' };
+            } else if (exchange.their.contains.keys && priceEntry.intent !== 0 && priceEntry.intent !== 2) {
+                // We are not buying keys
+                offer.log('info', 'we are not buying keys, declining...');
+                return { action: 'decline', reason: 'NOT_TRADING_KEYS' };
+            } else {
+                // Check overstock / understock on keys
+                const diff = itemsDiff['5021;6'];
+                // If the diff is greater than 0 then we are buying, less than is selling
+
+                const buying = diff > 0;
+                const amountCanTrade = this.bot.inventoryManager.amountCanTrade('5021;6', buying);
+
+                if (diff !== 0 && amountCanTrade < diff) {
+                    // User is taking too many / offering too many
+                    hasOverstock = true;
+                    wrongAboutOffer.push({
+                        reason: 'OVERSTOCKED',
+                        sku: '5021;6',
+                        buying: buying,
+                        diff: diff,
+                        amountCanTrade: amountCanTrade
+                    });
+                }
+            }
+        }
+
+        let hasInvalidValue = false;
+
+        if (exchange.our.value > exchange.their.value) {
+            // Check if the values are correct
+            hasInvalidValue = true;
+            wrongAboutOffer.push({
+                reason: 'INVALID_VALUE',
+                our: exchange.our.value,
+                their: exchange.their.value
+            });
+        }
+
+        if (!manualReviewEnabled) {
+            if (hasOverstock) {
+                offer.log('info', 'is taking / offering too many, declining...');
+
+                const reasons = wrongAboutOffer.map(wrong => wrong.reason);
+                const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
+
+                return {
+                    action: 'decline',
+                    reason: 'OVERSTOCKED',
+                    meta: {
+                        uniqueReasons: uniqueReasons,
+                        reasons: wrongAboutOffer
+                    }
+                };
             }
 
             if (hasInvalidItems) {
-                // Using boolean because items dict always needs to be saved
-                offer.log('info', 'contains items not from TF2, declining...');
-                return resolve({ action: 'decline', reason: 'INVALID_ITEMS' });
-            }
+                offer.log('info', 'contains items we are not trading, declining...');
 
-            const itemsDiff = offer.getDiff();
+                const reasons = wrongAboutOffer.map(wrong => wrong.reason);
+                const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
 
-            if (offer.itemsToGive.length === 0 && ['donate', 'gift'].includes(offer.message.toLowerCase())) {
-                offer.log('trade', 'is a gift offer, accepting. Summary:\n' + offer.summarize(this.bot.schema));
-                return resolve({ action: 'accept', reason: 'GIFT' });
-            } else if (offer.itemsToReceive.length === 0 || offer.itemsToGive.length === 0) {
-                offer.log('info', 'is a gift offer, declining...');
-                return resolve({ action: 'decline', reason: 'GIFT' });
-            }
-
-            const manualReviewEnabled = process.env.ENABLE_MANUAL_REVIEW === 'true';
-
-            const itemPrices = {};
-
-            const keyPrice = this.bot.pricelist.getKeyPrice();
-
-            let hasOverstock = false;
-
-            // A list of things that is wrong about the offer and other information
-            const wrongAboutOffer: (
-                | {
-                      reason: 'OVERSTOCKED';
-                      sku: string;
-                      buying: boolean;
-                      diff: number;
-                      amountCanTrade: number;
-                  }
-                | {
-                      reason: 'INVALID_ITEMS';
-                      sku: string;
-                      buying: boolean;
-                      amount: number;
-                  }
-                | {
-                      reason: 'INVALID_VALUE';
-                      our: number;
-                      their: number;
-                  }
-            )[] = [];
-
-            for (let i = 0; i < states.length; i++) {
-                const buying = states[i];
-                const which = buying ? 'their' : 'our';
-                const intentString = buying ? 'buy' : 'sell';
-
-                for (const sku in items[which]) {
-                    if (!Object.prototype.hasOwnProperty.call(items[which], sku)) {
-                        continue;
+                return {
+                    action: 'decline',
+                    reason: 'INVALID_ITEMS',
+                    meta: {
+                        uniqueReasons: uniqueReasons,
+                        reasons: wrongAboutOffer
                     }
-
-                    const assetids = items[which][sku];
-                    const amount = assetids.length;
-
-                    if (sku === '5000;6') {
-                        exchange[which].value += amount;
-                        exchange[which].scrap += amount;
-                    } else if (sku === '5001;6') {
-                        const value = 3 * amount;
-                        exchange[which].value += value;
-                        exchange[which].scrap += value;
-                    } else if (sku === '5002;6') {
-                        const value = 9 * amount;
-                        exchange[which].value += value;
-                        exchange[which].scrap += value;
-                    } else {
-                        const match = this.bot.pricelist.getPrice(sku, true);
-
-                        // TODO: Go through all assetids and check if the item is being sold for a specific price
-
-                        if (match !== null && (sku !== '5021;6' || !exchange.contains.items)) {
-                            // If we found a matching price and the item is not a key, or the we are not trading items (meaning that we are trading keys) then add the price of the item
-
-                            // Add value of items
-                            exchange[which].value += match[intentString].toValue(keyPrice.metal) * amount;
-                            exchange[which].keys += match[intentString].keys * amount;
-                            exchange[which].scrap += Currencies.toScrap(match[intentString].metal) * amount;
-
-                            itemPrices[match.sku] = {
-                                buy: match.buy,
-                                sell: match.sell
-                            };
-
-                            // Check stock limits (not for keys)
-                            const diff = itemsDiff[sku];
-
-                            const buyingOverstockCheck = diff > 0;
-                            const amountCanTrade = this.bot.inventoryManager.amountCanTrade(sku, buyingOverstockCheck);
-
-                            if (diff !== 0 && amountCanTrade < diff) {
-                                // User is taking too many / offering too many
-                                hasOverstock = true;
-
-                                wrongAboutOffer.push({
-                                    reason: 'OVERSTOCKED',
-                                    sku: sku,
-                                    buying: buyingOverstockCheck,
-                                    diff: diff,
-                                    amountCanTrade: amountCanTrade
-                                });
-                            }
-                        } else if (sku === '5021;6' && exchange.contains.items) {
-                            // Offer contains keys and we are not trading keys, add key value
-                            exchange[which].value += keyPrice.toValue() * amount;
-                            exchange[which].keys += amount;
-                        } else if (match === null || match.intent === (buying ? 1 : 0)) {
-                            // Offer contains an item that we are not trading
-                            hasInvalidItems = true;
-
-                            wrongAboutOffer.push({
-                                reason: 'INVALID_ITEMS',
-                                sku: sku,
-                                buying: buying,
-                                amount: amount
-                            });
-                        }
-                    }
-                }
+                };
             }
 
-            // Doing this so that the prices will always be displayed as only metal
-            exchange.our.scrap += exchange.our.keys * keyPrice.toValue();
-            exchange.our.keys = 0;
-            exchange.their.scrap += exchange.their.keys * keyPrice.toValue();
-            exchange.their.keys = 0;
+            if (hasInvalidValue) {
+                // We are offering more than them, decline the offer
+                offer.log('info', 'is not offering enough, declining...');
 
-            offer.data('value', {
-                our: {
-                    total: exchange.our.value,
-                    keys: exchange.our.keys,
-                    metal: Currencies.toRefined(exchange.our.scrap)
-                },
-                their: {
-                    total: exchange.their.value,
-                    keys: exchange.their.keys,
-                    metal: Currencies.toRefined(exchange.their.scrap)
-                },
-                rate: keyPrice.metal
+                const reasons = wrongAboutOffer.map(wrong => wrong.reason);
+                const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
+
+                return {
+                    action: 'decline',
+                    reason: 'INVALID_VALUE',
+                    meta: {
+                        uniqueReasons: uniqueReasons,
+                        reasons: wrongAboutOffer
+                    }
+                };
+            }
+        }
+
+        if (exchange.our.value < exchange.their.value && process.env.ALLOW_OVERPAY === 'false') {
+            offer.log('info', 'is offering more than needed, declining...');
+            return { action: 'decline', reason: 'OVERPAY' };
+        }
+
+        // TODO: If we are receiving items, mark them as pending and use it to check overstock / understock for new offers
+
+        offer.log('info', 'checking escrow...');
+
+        try {
+            const hasEscrow = await this.bot.checkEscrow(offer);
+
+            if (hasEscrow) {
+                offer.log('info', 'would be held if accepted, declining...');
+                return { action: 'decline', reason: 'ESCROW' };
+            }
+        } catch (err) {
+            log.warn('Failed to check escrow: ', err);
+            return;
+        }
+
+        offer.log('info', 'checking bans...');
+
+        try {
+            const isBanned = await this.bot.checkBanned(offer.partner.getSteamID64());
+
+            if (isBanned) {
+                offer.log('info', 'partner is banned in one or more communities, declining...');
+                return { action: 'decline', reason: 'BANNED' };
+            }
+        } catch (err) {
+            log.warn('Failed to check banned: ', err);
+            return;
+        }
+
+        if (this.dupeCheckEnabled && assetidsToCheck.length > 0) {
+            offer.log('info', 'checking ' + pluralize('item', assetidsToCheck.length, true) + ' for dupes...');
+            const inventory = new TF2Inventory(offer.partner, this.bot.manager);
+
+            const requests = assetidsToCheck.map(assetid => {
+                return (callback: (err: Error | null, result: boolean | null) => void): void => {
+                    log.debug('Dupe checking ' + assetid + '...');
+                    Promise.resolve(inventory.isDuped(assetid)).asCallback(function(err, result) {
+                        log.debug('Dupe check for ' + assetid + ' done');
+                        callback(err, result);
+                    });
+                };
             });
 
-            offer.data('prices', itemPrices);
+            try {
+                const result: (boolean | null)[] = await Promise.fromCallback(function(callback) {
+                    async.series(requests, callback);
+                });
 
-            if (exchange.contains.metal && !exchange.contains.keys && !exchange.contains.items) {
-                // Offer only contains metal
-                offer.log('info', 'only contains metal, declining...');
-                return resolve({ action: 'decline', reason: 'ONLY_METAL' });
-            } else if (exchange.contains.keys && !exchange.contains.items) {
-                // Offer is for trading keys, check if we are trading them
-                const priceEntry = this.bot.pricelist.getPrice('5021;6', true);
-                if (priceEntry === null) {
-                    // We are not trading keys
-                    offer.log('info', 'we are not trading keys, declining...');
-                    return resolve({ action: 'decline', reason: 'NOT_TRADING_KEYS' });
-                } else if (exchange.our.contains.keys && priceEntry.intent !== 1 && priceEntry.intent !== 2) {
-                    // We are not selling keys
-                    offer.log('info', 'we are not selling keys, declining...');
-                    return resolve({ action: 'decline', reason: 'NOT_TRADING_KEYS' });
-                } else if (exchange.their.contains.keys && priceEntry.intent !== 0 && priceEntry.intent !== 2) {
-                    // We are not buying keys
-                    offer.log('info', 'we are not buying keys, declining...');
-                    return resolve({ action: 'decline', reason: 'NOT_TRADING_KEYS' });
-                } else {
-                    // Check overstock / understock on keys
-                    const diff = itemsDiff['5021;6'];
-                    // If the diff is greater than 0 then we are buying, less than is selling
+                log.debug('Got result from dupe checks', { result: result });
 
-                    const buying = diff > 0;
-                    const amountCanTrade = this.bot.inventoryManager.amountCanTrade('5021;6', buying);
+                // Decline by default
+                const declineDupes = process.env.DECLINE_DUPES !== 'false';
 
-                    if (diff !== 0 && amountCanTrade < diff) {
-                        // User is taking too many / offering too many
-                        hasOverstock = true;
+                for (let i = 0; i < result.length; i++) {
+                    if (result[i] === true) {
+                        // Found duped item
+                        if (declineDupes) {
+                            // Offer contains duped items, decline it
+                            return {
+                                action: 'decline',
+                                reason: 'DUPED_ITEMS',
+                                meta: { assetids: assetidsToCheck, result: result }
+                            };
+                        } else {
+                            // Offer contains duped items but we don't decline duped items, instead add it to the wrong about offer list and continue
+                            wrongAboutOffer.push({
+                                reason: 'DUPED_ITEMS',
+                                assetid: assetidsToCheck[i]
+                            });
+                        }
+                    } else if (result[i] === null) {
+                        // Could not determine if the item was duped, make the offer be pending for review
                         wrongAboutOffer.push({
-                            reason: 'OVERSTOCKED',
-                            sku: '5021;6',
-                            buying: buying,
-                            diff: diff,
-                            amountCanTrade: amountCanTrade
+                            reason: 'DUPE_CHECK_FAILED',
+                            assetid: assetidsToCheck[i]
                         });
                     }
                 }
-            }
-
-            let hasInvalidValue = false;
-
-            if (exchange.our.value > exchange.their.value) {
-                // Check if the values are correct
-                hasInvalidValue = true;
+            } catch (err) {
+                log.warn('Failed dupe check: ' + err.message);
                 wrongAboutOffer.push({
-                    reason: 'INVALID_VALUE',
-                    our: exchange.our.value,
-                    their: exchange.their.value
+                    reason: 'DUPE_CHECK_FAILED',
+                    error: err.message
                 });
             }
+        }
 
+        if (wrongAboutOffer.length !== 0) {
             const reasons = wrongAboutOffer.map(wrong => wrong.reason);
             const uniqueReasons = reasons.filter(reason => reasons.includes(reason));
 
-            if (!manualReviewEnabled) {
-                if (hasOverstock) {
-                    offer.log('info', 'is taking / offering too many, declining...');
-                    return resolve({
-                        action: 'decline',
-                        reason: 'OVERSTOCKED',
-                        meta: {
-                            uniqueReasons: uniqueReasons,
-                            reasons: wrongAboutOffer
-                        }
-                    });
+            offer.log('info', 'offer needs review (' + uniqueReasons.join(', ') + '), skipping...');
+            return {
+                action: 'skip',
+                reason: 'REVIEW',
+                meta: {
+                    uniqueReasons: uniqueReasons,
+                    reasons: wrongAboutOffer
                 }
+            };
+        }
 
-                if (hasInvalidItems) {
-                    offer.log('info', 'contains items we are not trading, declining...');
-                    return resolve({
-                        action: 'decline',
-                        reason: 'INVALID_ITEMS',
-                        meta: {
-                            uniqueReasons: uniqueReasons,
-                            reasons: wrongAboutOffer
-                        }
-                    });
-                }
+        offer.log('trade', 'accepting. Summary:\n' + offer.summarize(this.bot.schema));
 
-                if (hasInvalidValue) {
-                    // We are offering more than them, decline the offer
-                    offer.log('info', 'is not offering enough, declining...');
-                    return resolve({
-                        action: 'decline',
-                        reason: 'INVALID_VALUE',
-                        meta: {
-                            uniqueReasons: uniqueReasons,
-                            reasons: wrongAboutOffer
-                        }
-                    });
-                }
-            }
-
-            if (exchange.our.value < exchange.their.value && process.env.ALLOW_OVERPAY === 'false') {
-                offer.log('info', 'is offering more than needed, declining...');
-                return resolve({ action: 'decline', reason: 'OVERPAY' });
-            }
-
-            // TODO: If we are receiving items, mark them as pending and use it to check overstock / understock for new offers
-
-            offer.log('info', 'checking escrow...');
-
-            this.bot.checkEscrow(offer).asCallback((err, escrow) => {
-                if (err) {
-                    log.warn('Failed to check escrow: ', err);
-                    return resolve();
-                }
-
-                if (escrow) {
-                    offer.log('info', 'would be held if accepted, declining...');
-                    return resolve({ action: 'decline', reason: 'ESCROW' });
-                }
-
-                offer.log('info', 'checking bans...');
-
-                this.bot.checkBanned(offer.partner.getSteamID64()).asCallback((err, banned) => {
-                    if (err) {
-                        log.warn('Failed to check banned: ', err);
-                        return resolve();
-                    }
-
-                    if (banned) {
-                        offer.log('info', 'partner is banned in one or more communities, declining...');
-                        return resolve({ action: 'decline', reason: 'BANNED' });
-                    }
-
-                    if (wrongAboutOffer.length !== 0) {
-                        offer.log('info', 'offer needs review (' + uniqueReasons.join(', ') + '), skipping...');
-                        return resolve({
-                            action: 'skip',
-                            reason: 'REVIEW',
-                            meta: {
-                                uniqueReasons: uniqueReasons,
-                                reasons: wrongAboutOffer
-                            }
-                        });
-                    }
-
-                    offer.log('trade', 'accepting. Summary:\n' + offer.summarize(this.bot.schema));
-
-                    return resolve({ action: 'accept', reason: 'VALID' });
-                });
-            });
-        });
+        return { action: 'accept', reason: 'VALID' };
     }
 
     // TODO: checkBanned and checkEscrow are copied from UserCart, don't duplicate them

--- a/src/classes/TF2Inventory.ts
+++ b/src/classes/TF2Inventory.ts
@@ -1,0 +1,172 @@
+import SteamID from 'steamid';
+import TradeOfferManager from 'steam-tradeoffer-manager';
+import request from '@nicklason/request-retry';
+import cheerio from 'cheerio';
+
+type TF2Attribute = {
+    defindex: number;
+    value: number | string;
+    float_value?: number;
+};
+
+type TF2Item = {
+    id: number;
+
+    original_id: number;
+
+    defindex: number;
+
+    level: number;
+
+    quality: number;
+
+    inventory: number;
+
+    quantity: number;
+
+    origin: number;
+
+    style?: number | undefined;
+
+    flag_cannot_trade?: boolean;
+
+    flag_cannot_craft?: boolean;
+
+    attributes?: TF2Attribute[];
+};
+
+export = class TF2Inventory {
+    private readonly steamID: SteamID;
+
+    private readonly manager: TradeOfferManager;
+
+    private items: TF2Item[] = [];
+
+    private slots: number = null;
+
+    constructor(steamID: SteamID | string, manager: TradeOfferManager) {
+        this.steamID = new SteamID(steamID.toString());
+        this.manager = manager;
+    }
+
+    getSteamID(): SteamID {
+        return this.steamID;
+    }
+
+    getItems(): TF2Item[] {
+        return this.items;
+    }
+
+    getSlots(): number {
+        return this.slots;
+    }
+
+    async isDuped(assetid: string): Promise<boolean | null> {
+        // Check if the item exists on backpack.tf and if it is duped
+        const history = await TF2Inventory.getItemHistory(assetid);
+
+        if (history.recorded === true) {
+            return history.isDuped;
+        }
+
+        // Inventory is not updated on bptf, get the original id
+
+        // Fetch inventory using TF2 GetPlayerItems API if we haven't already
+        if (this.getItems().length === 0) {
+            await this.fetch();
+        }
+
+        // Find item in the inventory
+        const item = this.getItems().find(item => item.id.toString() == assetid);
+
+        if (item === undefined) {
+            // Could not find the item in the inventory, failed to check if the item is duped
+            throw new Error('Could not find item in inventory');
+        }
+
+        // Get history using original id
+        const historyFromOriginal = await TF2Inventory.getItemHistory(item.original_id.toString());
+
+        if (historyFromOriginal.recorded === true) {
+            return history.isDuped;
+        }
+
+        // Item has never been seen on backpack.tf before
+        // throw new Error('No history for given item');
+
+        return null;
+    }
+
+    fetch(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            request(
+                {
+                    url: 'https://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/',
+                    method: 'GET',
+                    qs: {
+                        key: this.manager.apiKey,
+                        steamid: this.getSteamID().toString()
+                    },
+                    json: true,
+                    gzip: true
+                },
+                (err, response, body) => {
+                    if (err) {
+                        return reject(err);
+                    }
+
+                    if (body.result.status != 1) {
+                        err = new Error(body.result.statusDetail);
+                        err.status = body.result.status;
+                        return reject(err);
+                    }
+
+                    this.slots = body.result.num_backpack_slots;
+                    this.items = body.result.items;
+
+                    return resolve();
+                }
+            );
+        });
+    }
+
+    static getItemHistory(
+        assetid: string
+    ): Promise<{
+        recorded: boolean;
+        isDuped?: boolean;
+        history?: [];
+    }> {
+        return new Promise((resolve, reject) => {
+            request(
+                {
+                    url: 'https://backpack.tf/item/' + assetid,
+                    method: 'GET'
+                },
+                function(err, response, body) {
+                    if (err) {
+                        return reject(err);
+                    }
+
+                    const $ = cheerio.load(body);
+
+                    if ($('table').length !== 1) {
+                        return resolve({
+                            recorded: false
+                        });
+                    }
+
+                    // TODO: Make a list that contains the item history
+
+                    const isDuped = $('#dupe-modal-btn').length > 0;
+
+                    return resolve({
+                        recorded: true,
+                        isDuped: isDuped,
+                        history: []
+                    });
+                }
+            );
+        });
+    }
+};

--- a/src/classes/Trades.ts
+++ b/src/classes/Trades.ts
@@ -262,7 +262,7 @@ export = class Trades {
 
         offer.data('handleTimestamp', start);
 
-        this.bot.handler.onNewTradeOffer(offer).asCallback((err, response) => {
+        Promise.resolve(this.bot.handler.onNewTradeOffer(offer)).asCallback((err, response) => {
             if (err) {
                 log.debug('Error occurred while handler was processing offer: ', err);
                 throw err;
@@ -278,6 +278,10 @@ export = class Trades {
             offer.log('debug', 'handler is done with offer', {
                 response: response
             });
+
+            if (!response) {
+                return this.finishProcessingOffer(offer.id);
+            }
 
             this.applyActionToOffer(response.action, response.reason, response.meta || {}, offer).finally(() => {
                 this.finishProcessingOffer(offer.id);

--- a/src/classes/UserCart.ts
+++ b/src/classes/UserCart.ts
@@ -1,9 +1,12 @@
 import pluralize from 'pluralize';
 import SKU from 'tf2-sku';
 import Currencies from 'tf2-currencies';
+import async from 'async';
 
 import Cart from './Cart';
 import Inventory from './Inventory';
+import TF2Inventory from './TF2Inventory';
+import MyHandler from './MyHandler';
 import { CurrencyObject, Currency } from '../types/TeamFortress2';
 import { UnknownDictionary } from '../types/common';
 
@@ -29,6 +32,45 @@ class UserCart extends Cart {
 
         if (escrow) {
             return Promise.reject('trade would be held');
+        }
+
+        // TODO: Check for dupes
+
+        if ((this.bot.handler as MyHandler).hasDupeCheckEnabled) {
+            const assetidsToCheck = this.offer.data('_dupeCheck');
+            this.offer.data('_dupeCheck', undefined);
+
+            const inventory = new TF2Inventory(this.partner, this.bot.manager);
+
+            const requests = assetidsToCheck.map(assetid => {
+                return (callback: (err: Error | null, result: boolean | null) => void): void => {
+                    log.debug('Dupe checking ' + assetid + '...');
+                    Promise.resolve(inventory.isDuped(assetid)).asCallback(function(err, result) {
+                        log.debug('Dupe check for ' + assetid + ' done');
+                        callback(err, result);
+                    });
+                };
+            });
+
+            try {
+                const result: (boolean | null)[] = await Promise.fromCallback(function(callback) {
+                    async.series(requests, callback);
+                });
+
+                log.debug('Got result from dupe checks', { result: result });
+
+                for (let i = 0; i < result.length; i++) {
+                    if (result[i] === true) {
+                        // Found duped item
+                        return Promise.reject('offer contains duped items');
+                    } else if (result[i] === null) {
+                        // Could not determine if the item was duped, make the offer be pending for review
+                        return Promise.reject('failed to check for duped items, try sending an offer instead');
+                    }
+                }
+            } catch (err) {
+                return Promise.reject('failed to check for duped items, try sending an offer instead');
+            }
         }
     }
 
@@ -317,417 +359,427 @@ class UserCart extends Cart {
         return summary;
     }
 
-    constructOffer(): Promise<string> {
-        return new Promise((resolve, reject) => {
-            if (this.isEmpty()) {
-                return reject('cart is empty');
+    async constructOffer(): Promise<string> {
+        if (this.isEmpty()) {
+            return Promise.reject('cart is empty');
+        }
+
+        const offer = this.bot.manager.createOffer(this.partner);
+
+        const alteredMessages: string[] = [];
+
+        // Add our items
+        const ourInventory = this.bot.inventoryManager.getInventory();
+
+        for (const sku in this.our) {
+            if (!Object.prototype.hasOwnProperty.call(this.our, sku)) {
+                continue;
             }
 
-            const offer = this.bot.manager.createOffer(this.partner);
+            let alteredMessage: string;
 
-            const alteredMessages: string[] = [];
+            let amount = this.getOurCount(sku);
+            const ourAssetids = ourInventory.findBySKU(sku, true);
 
-            // Add our items
-            const ourInventory = this.bot.inventoryManager.getInventory();
+            if (amount > ourAssetids.length) {
+                amount = ourAssetids.length;
 
-            for (const sku in this.our) {
-                if (!Object.prototype.hasOwnProperty.call(this.our, sku)) {
+                // Remove the item from the cart
+                this.removeOurItem(sku, Infinity);
+
+                if (ourAssetids.length === 0) {
+                    alteredMessage =
+                        "I don't have any " + pluralize(this.bot.schema.getName(SKU.fromString(sku), false));
+                } else {
+                    alteredMessage =
+                        'I only have ' +
+                        pluralize(this.bot.schema.getName(SKU.fromString(sku), false), ourAssetids.length, true);
+
+                    // Add the max amount to the cart
+                    this.addOurItem(sku, amount);
+                }
+            }
+
+            const amountCanTrade = this.bot.inventoryManager.amountCanTrade(sku, false);
+
+            if (amount > amountCanTrade) {
+                this.removeOurItem(sku, Infinity);
+                if (amountCanTrade === 0) {
+                    alteredMessage = "I can't sell more " + this.bot.schema.getName(SKU.fromString(sku), false);
+                } else {
+                    amount = amountCanTrade;
+                    alteredMessage =
+                        'I can only sell ' +
+                        amountCanTrade +
+                        ' more ' +
+                        this.bot.schema.getName(SKU.fromString(sku), false);
+
+                    this.addOurItem(sku, amount);
+                }
+            }
+
+            if (alteredMessage) {
+                alteredMessages.push(alteredMessage);
+            }
+        }
+
+        // Load their inventory
+
+        const theirInventory = new Inventory(this.partner, this.bot.manager, this.bot.schema);
+
+        try {
+            await theirInventory.fetch();
+        } catch (err) {
+            return Promise.reject('Failed to load inventories (Steam might be down)');
+        }
+
+        // Add their items
+
+        for (const sku in this.their) {
+            if (!Object.prototype.hasOwnProperty.call(this.their, sku)) {
+                continue;
+            }
+
+            let alteredMessage: string;
+
+            let amount = this.getTheirCount(sku);
+            const theirAssetids = theirInventory.findBySKU(sku, true);
+
+            if (amount > theirAssetids.length) {
+                // Remove the item from the cart
+                this.removeTheirItem(sku, Infinity);
+
+                if (theirAssetids.length === 0) {
+                    alteredMessage =
+                        "you don't have any " + pluralize(this.bot.schema.getName(SKU.fromString(sku), false));
+                } else {
+                    amount = theirAssetids.length;
+                    alteredMessage =
+                        'you only have ' +
+                        pluralize(this.bot.schema.getName(SKU.fromString(sku), false), theirAssetids.length, true);
+
+                    // Add the max amount to the cart
+                    this.addTheirItem(sku, amount);
+                }
+            }
+
+            const amountCanTrade = this.bot.inventoryManager.amountCanTrade(sku, true);
+
+            if (amount > amountCanTrade) {
+                this.removeTheirItem(sku, Infinity);
+                if (amountCanTrade === 0) {
+                    alteredMessage =
+                        "I can't buy more " + pluralize(this.bot.schema.getName(SKU.fromString(sku), false));
+                } else {
+                    amount = amountCanTrade;
+                    alteredMessage =
+                        'I can only buy ' +
+                        amountCanTrade +
+                        ' more ' +
+                        pluralize(this.bot.schema.getName(SKU.fromString(sku), false), amountCanTrade);
+
+                    this.addTheirItem(sku, amount);
+                }
+            }
+
+            if (alteredMessage) {
+                alteredMessages.push(alteredMessage);
+            }
+        }
+
+        if (this.isEmpty()) {
+            return Promise.reject(alteredMessages.join(', '));
+        }
+
+        const itemsDict: {
+            our: UnknownDictionary<number>;
+            their: UnknownDictionary<number>;
+        } = {
+            our: Object.assign({}, this.our),
+            their: Object.assign({}, this.their)
+        };
+
+        // Done checking if buyer and seller has the items and if the bot wants to buy / sell more
+
+        // Add values to the offer
+
+        // Figure out who the buyer is and what they are offering
+        const { isBuyer, currencies } = this.getCurrencies();
+
+        // We now know who the buyer is, now get their inventory
+        const buyerInventory = isBuyer ? this.bot.inventoryManager.getInventory() : theirInventory;
+
+        if (this.bot.inventoryManager.amountCanAfford(this.canUseKeys(), currencies, buyerInventory) < 1) {
+            // Buyer can't afford the items
+            return Promise.reject((isBuyer ? 'I' : 'You') + " don't have enough pure for this trade");
+        }
+
+        const keyPrice = this.bot.pricelist.getKeyPrice();
+
+        const ourItemsValue = this.getOurCurrencies().toValue(keyPrice.metal);
+        const theirItemsValue = this.getTheirCurrencies().toValue(keyPrice.metal);
+
+        // Create exchange object with our and their items values
+        const exchange = {
+            our: { value: ourItemsValue, keys: 0, scrap: ourItemsValue },
+            their: { value: theirItemsValue, keys: 0, scrap: theirItemsValue }
+        };
+
+        // Figure out what pure to pick from the buyer, and if change is needed
+
+        const buyerCurrenciesWithAssetids = buyerInventory.getCurrencies();
+
+        const buyerCurrenciesCount = {
+            '5021;6': buyerCurrenciesWithAssetids['5021;6'].length,
+            '5002;6': buyerCurrenciesWithAssetids['5002;6'].length,
+            '5001;6': buyerCurrenciesWithAssetids['5001;6'].length,
+            '5000;6': buyerCurrenciesWithAssetids['5000;6'].length
+        };
+
+        const required = this.getRequired(buyerCurrenciesCount, currencies, this.canUseKeys());
+
+        // Add the value that the buyer pays to the exchange
+        exchange[isBuyer ? 'our' : 'their'].value += currencies.toValue(keyPrice.metal);
+        exchange[isBuyer ? 'our' : 'their'].keys += required.currencies['5021;6'];
+        exchange[isBuyer ? 'our' : 'their'].scrap +=
+            required.currencies['5002;6'] * 9 + required.currencies['5001;6'] * 3 + required.currencies['5000;6'];
+
+        // Add items to offer
+
+        // Add our items
+        for (const sku in this.our) {
+            const amount = this.our[sku];
+            const assetids = ourInventory.findBySKU(sku, true);
+
+            let missing = amount;
+
+            for (let i = 0; i < assetids.length; i++) {
+                const isAdded = offer.addMyItem({
+                    appid: 440,
+                    contextid: '2',
+                    assetid: assetids[i]
+                });
+
+                if (isAdded) {
+                    // The item was added to the offer
+                    missing--;
+                    if (missing === 0) {
+                        // We added all the items
+                        break;
+                    }
+                }
+            }
+
+            if (missing !== 0) {
+                log.warn('Failed to create offer because missing our items', {
+                    sku: sku,
+                    required: amount,
+                    missing: missing
+                });
+
+                return Promise.reject('Something went wrong while constructing the offer');
+            }
+        }
+
+        const assetidsToCheck: string[] = [];
+
+        // Add their items
+        for (const sku in this.their) {
+            const amount = this.their[sku];
+            const assetids = theirInventory.findBySKU(sku, true);
+
+            const match = this.bot.pricelist.getPrice(sku, true);
+
+            const item = SKU.fromString(sku);
+
+            const addToDupeCheckList =
+                item.effect !== null &&
+                match.buy.toValue(keyPrice.metal) >
+                    (this.bot.handler as MyHandler).getMinimumKeysDupeCheck() * keyPrice.toValue();
+
+            let missing = amount;
+
+            for (let i = 0; i < assetids.length; i++) {
+                const isAdded = offer.addTheirItem({
+                    appid: 440,
+                    contextid: '2',
+                    assetid: assetids[i]
+                });
+
+                if (isAdded) {
+                    missing--;
+
+                    if (addToDupeCheckList) {
+                        assetidsToCheck.push(assetids[i]);
+                    }
+
+                    if (missing === 0) {
+                        break;
+                    }
+                }
+            }
+
+            if (missing !== 0) {
+                log.warn('Failed to create offer because missing their items', {
+                    sku: sku,
+                    required: amount,
+                    missing: missing
+                });
+
+                return Promise.reject('Something went wrong while constructing the offer');
+            }
+        }
+
+        const sellerInventory = isBuyer ? theirInventory : ourInventory;
+
+        if (required.change !== 0) {
+            let change = Math.abs(required.change);
+
+            exchange[isBuyer ? 'their' : 'our'].value += change;
+            exchange[isBuyer ? 'their' : 'our'].scrap += change;
+
+            const currencies = sellerInventory.getCurrencies();
+            // We won't use keys when giving change
+            delete currencies['5021;6'];
+
+            for (const sku in currencies) {
+                if (!Object.prototype.hasOwnProperty.call(currencies, sku)) {
                     continue;
                 }
 
-                let alteredMessage: string;
+                let value = 0;
 
-                let amount = this.getOurCount(sku);
-                const ourAssetids = ourInventory.findBySKU(sku, true);
-
-                if (amount > ourAssetids.length) {
-                    amount = ourAssetids.length;
-
-                    // Remove the item from the cart
-                    this.removeOurItem(sku, Infinity);
-
-                    if (ourAssetids.length === 0) {
-                        alteredMessage =
-                            "I don't have any " + pluralize(this.bot.schema.getName(SKU.fromString(sku), false));
-                    } else {
-                        alteredMessage =
-                            'I only have ' +
-                            pluralize(this.bot.schema.getName(SKU.fromString(sku), false), ourAssetids.length, true);
-
-                        // Add the max amount to the cart
-                        this.addOurItem(sku, amount);
-                    }
+                if (sku === '5002;6') {
+                    value = 9;
+                } else if (sku === '5001;6') {
+                    value = 3;
+                } else if (sku === '5000;6') {
+                    value = 1;
                 }
 
-                const amountCanTrade = this.bot.inventoryManager.amountCanTrade(sku, false);
+                if (change / value >= 1) {
+                    const whose = isBuyer ? 'their' : 'our';
 
-                if (amount > amountCanTrade) {
-                    this.removeOurItem(sku, Infinity);
-                    if (amountCanTrade === 0) {
-                        alteredMessage = "I can't sell more " + this.bot.schema.getName(SKU.fromString(sku), false);
-                    } else {
-                        amount = amountCanTrade;
-                        alteredMessage =
-                            'I can only sell ' +
-                            amountCanTrade +
-                            ' more ' +
-                            this.bot.schema.getName(SKU.fromString(sku), false);
-
-                        this.addOurItem(sku, amount);
-                    }
-                }
-
-                if (alteredMessage) {
-                    alteredMessages.push(alteredMessage);
-                }
-            }
-
-            // Load their inventory
-
-            const theirInventory = new Inventory(this.partner, this.bot.manager, this.bot.schema);
-
-            theirInventory.fetch().asCallback(err => {
-                if (err) {
-                    return reject('Failed to load inventories (Steam might be down)');
-                }
-
-                // Add their items
-
-                for (const sku in this.their) {
-                    if (!Object.prototype.hasOwnProperty.call(this.their, sku)) {
-                        continue;
-                    }
-
-                    let alteredMessage: string;
-
-                    let amount = this.getTheirCount(sku);
-                    const theirAssetids = theirInventory.findBySKU(sku, true);
-
-                    if (amount > theirAssetids.length) {
-                        // Remove the item from the cart
-                        this.removeTheirItem(sku, Infinity);
-
-                        if (theirAssetids.length === 0) {
-                            alteredMessage =
-                                "you don't have any " + pluralize(this.bot.schema.getName(SKU.fromString(sku), false));
-                        } else {
-                            amount = theirAssetids.length;
-                            alteredMessage =
-                                'you only have ' +
-                                pluralize(
-                                    this.bot.schema.getName(SKU.fromString(sku), false),
-                                    theirAssetids.length,
-                                    true
-                                );
-
-                            // Add the max amount to the cart
-                            this.addTheirItem(sku, amount);
-                        }
-                    }
-
-                    const amountCanTrade = this.bot.inventoryManager.amountCanTrade(sku, true);
-
-                    if (amount > amountCanTrade) {
-                        this.removeTheirItem(sku, Infinity);
-                        if (amountCanTrade === 0) {
-                            alteredMessage =
-                                "I can't buy more " + pluralize(this.bot.schema.getName(SKU.fromString(sku), false));
-                        } else {
-                            amount = amountCanTrade;
-                            alteredMessage =
-                                'I can only buy ' +
-                                amountCanTrade +
-                                ' more ' +
-                                pluralize(this.bot.schema.getName(SKU.fromString(sku), false), amountCanTrade);
-
-                            this.addTheirItem(sku, amount);
-                        }
-                    }
-
-                    if (alteredMessage) {
-                        alteredMessages.push(alteredMessage);
-                    }
-                }
-
-                if (this.isEmpty()) {
-                    return reject(alteredMessages.join(', '));
-                }
-
-                const itemsDict: {
-                    our: UnknownDictionary<number>;
-                    their: UnknownDictionary<number>;
-                } = {
-                    our: Object.assign({}, this.our),
-                    their: Object.assign({}, this.their)
-                };
-
-                // Done checking if buyer and seller has the items and if the bot wants to buy / sell more
-
-                // Add values to the offer
-
-                // Figure out who the buyer is and what they are offering
-                const { isBuyer, currencies } = this.getCurrencies();
-
-                // We now know who the buyer is, now get their inventory
-                const buyerInventory = isBuyer ? this.bot.inventoryManager.getInventory() : theirInventory;
-
-                if (this.bot.inventoryManager.amountCanAfford(this.canUseKeys(), currencies, buyerInventory) < 1) {
-                    // Buyer can't afford the items
-                    return reject((isBuyer ? 'I' : 'You') + " don't have enough pure for this trade");
-                }
-
-                const keyPrice = this.bot.pricelist.getKeyPrice();
-
-                const ourItemsValue = this.getOurCurrencies().toValue(keyPrice.metal);
-                const theirItemsValue = this.getTheirCurrencies().toValue(keyPrice.metal);
-
-                // Create exchange object with our and their items values
-                const exchange = {
-                    our: { value: ourItemsValue, keys: 0, scrap: ourItemsValue },
-                    their: { value: theirItemsValue, keys: 0, scrap: theirItemsValue }
-                };
-
-                // Figure out what pure to pick from the buyer, and if change is needed
-
-                const buyerCurrenciesWithAssetids = buyerInventory.getCurrencies();
-
-                const buyerCurrenciesCount = {
-                    '5021;6': buyerCurrenciesWithAssetids['5021;6'].length,
-                    '5002;6': buyerCurrenciesWithAssetids['5002;6'].length,
-                    '5001;6': buyerCurrenciesWithAssetids['5001;6'].length,
-                    '5000;6': buyerCurrenciesWithAssetids['5000;6'].length
-                };
-
-                const required = this.getRequired(buyerCurrenciesCount, currencies, this.canUseKeys());
-
-                // Add the value that the buyer pays to the exchange
-                exchange[isBuyer ? 'our' : 'their'].value += currencies.toValue(keyPrice.metal);
-                exchange[isBuyer ? 'our' : 'their'].keys += required.currencies['5021;6'];
-                exchange[isBuyer ? 'our' : 'their'].scrap +=
-                    required.currencies['5002;6'] * 9 +
-                    required.currencies['5001;6'] * 3 +
-                    required.currencies['5000;6'];
-
-                // Add items to offer
-
-                // Add our items
-                for (const sku in this.our) {
-                    const amount = this.our[sku];
-                    const assetids = ourInventory.findBySKU(sku, true);
-
-                    let missing = amount;
-
-                    for (let i = 0; i < assetids.length; i++) {
-                        const isAdded = offer.addMyItem({
-                            appid: 440,
-                            contextid: '2',
-                            assetid: assetids[i]
-                        });
-
-                        if (isAdded) {
-                            // The item was added to the offer
-                            missing--;
-                            if (missing === 0) {
-                                // We added all the items
-                                break;
-                            }
-                        }
-                    }
-
-                    if (missing !== 0) {
-                        log.warn('Failed to create offer because missing our items', {
-                            sku: sku,
-                            required: amount,
-                            missing: missing
-                        });
-
-                        return reject('Something went wrong while constructing the offer');
-                    }
-                }
-
-                // Add their items
-                for (const sku in this.their) {
-                    const amount = this.their[sku];
-                    const assetids = theirInventory.findBySKU(sku, true);
-
-                    let missing = amount;
-
-                    for (let i = 0; i < assetids.length; i++) {
-                        const isAdded = offer.addTheirItem({
-                            appid: 440,
-                            contextid: '2',
-                            assetid: assetids[i]
-                        });
-
-                        if (isAdded) {
-                            missing--;
-                            if (missing === 0) {
-                                break;
-                            }
-                        }
-                    }
-
-                    if (missing !== 0) {
-                        log.warn('Failed to create offer because missing their items', {
-                            sku: sku,
-                            required: amount,
-                            missing: missing
-                        });
-
-                        return reject('Something went wrong while constructing the offer');
-                    }
-                }
-
-                const sellerInventory = isBuyer ? theirInventory : ourInventory;
-
-                if (required.change !== 0) {
-                    let change = Math.abs(required.change);
-
-                    exchange[isBuyer ? 'their' : 'our'].value += change;
-                    exchange[isBuyer ? 'their' : 'our'].scrap += change;
-
-                    const currencies = sellerInventory.getCurrencies();
-                    // We won't use keys when giving change
-                    delete currencies['5021;6'];
-
-                    for (const sku in currencies) {
-                        if (!Object.prototype.hasOwnProperty.call(currencies, sku)) {
-                            continue;
-                        }
-
-                        let value = 0;
-
-                        if (sku === '5002;6') {
-                            value = 9;
-                        } else if (sku === '5001;6') {
-                            value = 3;
-                        } else if (sku === '5000;6') {
-                            value = 1;
-                        }
-
-                        if (change / value >= 1) {
-                            const whose = isBuyer ? 'their' : 'our';
-
-                            for (let i = 0; i < currencies[sku].length; i++) {
-                                const isAdded = offer[isBuyer ? 'addTheirItem' : 'addMyItem']({
-                                    assetid: currencies[sku][i],
-                                    appid: 440,
-                                    contextid: '2',
-                                    amount: 1
-                                });
-
-                                if (isAdded) {
-                                    itemsDict[whose][sku] = (itemsDict[whose][sku] || 0) + 1;
-                                    change -= value;
-                                    if (change < value) {
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    if (change !== 0) {
-                        return reject('I am missing ' + Currencies.toRefined(change) + ' ref as change');
-                    }
-                }
-
-                for (const sku in required.currencies) {
-                    if (!Object.prototype.hasOwnProperty.call(required.currencies, sku)) {
-                        continue;
-                    }
-
-                    if (required.currencies[sku] === 0) {
-                        continue;
-                    }
-
-                    itemsDict[isBuyer ? 'our' : 'their'][sku] = required.currencies[sku];
-
-                    for (let i = 0; i < buyerCurrenciesWithAssetids[sku].length; i++) {
-                        const isAdded = offer[isBuyer ? 'addMyItem' : 'addTheirItem']({
-                            assetid: buyerCurrenciesWithAssetids[sku][i],
+                    for (let i = 0; i < currencies[sku].length; i++) {
+                        const isAdded = offer[isBuyer ? 'addTheirItem' : 'addMyItem']({
+                            assetid: currencies[sku][i],
                             appid: 440,
                             contextid: '2',
                             amount: 1
                         });
 
                         if (isAdded) {
-                            required.currencies[sku]--;
-                            if (required.currencies[sku] === 0) {
+                            itemsDict[whose][sku] = (itemsDict[whose][sku] || 0) + 1;
+                            change -= value;
+                            if (change < value) {
                                 break;
                             }
                         }
                     }
-
-                    if (required.currencies[sku] !== 0) {
-                        log.warn('Failed to create offer because missing buyer pure', {
-                            requiredCurrencies: required.currencies,
-                            sku: sku
-                        });
-
-                        return reject('Something went wrong while constructing the offer');
-                    }
                 }
+            }
 
-                const itemPrices: UnknownDictionary<{ buy: Currency; sell: Currency }> = {};
+            if (change !== 0) {
+                return Promise.reject('I am missing ' + Currencies.toRefined(change) + ' ref as change');
+            }
+        }
 
-                for (const sku in this.our) {
-                    if (!Object.prototype.hasOwnProperty.call(this.their, sku)) {
-                        continue;
-                    }
+        for (const sku in required.currencies) {
+            if (!Object.prototype.hasOwnProperty.call(required.currencies, sku)) {
+                continue;
+            }
 
-                    const entry = this.bot.pricelist.getPrice(sku, true);
+            if (required.currencies[sku] === 0) {
+                continue;
+            }
 
-                    itemPrices[sku] = {
-                        buy: entry.buy.toJSON(),
-                        sell: entry.sell.toJSON()
-                    };
-                }
+            itemsDict[isBuyer ? 'our' : 'their'][sku] = required.currencies[sku];
 
-                for (const sku in this.their) {
-                    if (!Object.prototype.hasOwnProperty.call(this.their, sku)) {
-                        continue;
-                    }
-
-                    if (itemPrices[sku] !== undefined) {
-                        continue;
-                    }
-
-                    const entry = this.bot.pricelist.getPrice(sku, true);
-
-                    itemPrices[sku] = {
-                        buy: entry.buy.toJSON(),
-                        sell: entry.sell.toJSON()
-                    };
-                }
-
-                // Doing this so that the prices will always be displayed as only metal
-                exchange.our.scrap += exchange.our.keys * keyPrice.toValue();
-                exchange.our.keys = 0;
-                exchange.their.scrap += exchange.their.keys * keyPrice.toValue();
-                exchange.their.keys = 0;
-
-                offer.data('dict', itemsDict);
-                offer.data('value', {
-                    our: {
-                        total: exchange.our.value,
-                        keys: exchange.our.keys,
-                        metal: Currencies.toRefined(exchange.our.scrap)
-                    },
-                    their: {
-                        total: exchange.their.value,
-                        keys: exchange.their.keys,
-                        metal: Currencies.toRefined(exchange.their.scrap)
-                    },
-                    rate: keyPrice.metal
+            for (let i = 0; i < buyerCurrenciesWithAssetids[sku].length; i++) {
+                const isAdded = offer[isBuyer ? 'addMyItem' : 'addTheirItem']({
+                    assetid: buyerCurrenciesWithAssetids[sku][i],
+                    appid: 440,
+                    contextid: '2',
+                    amount: 1
                 });
-                offer.data('prices', itemPrices);
 
-                this.offer = offer;
+                if (isAdded) {
+                    required.currencies[sku]--;
+                    if (required.currencies[sku] === 0) {
+                        break;
+                    }
+                }
+            }
 
-                return resolve(alteredMessages.length === 0 ? undefined : alteredMessages.join(', '));
-            });
+            if (required.currencies[sku] !== 0) {
+                log.warn('Failed to create offer because missing buyer pure', {
+                    requiredCurrencies: required.currencies,
+                    sku: sku
+                });
+
+                return Promise.reject('Something went wrong while constructing the offer');
+            }
+        }
+
+        const itemPrices: UnknownDictionary<{ buy: Currency; sell: Currency }> = {};
+
+        for (const sku in this.our) {
+            if (!Object.prototype.hasOwnProperty.call(this.their, sku)) {
+                continue;
+            }
+
+            const entry = this.bot.pricelist.getPrice(sku, true);
+
+            itemPrices[sku] = {
+                buy: entry.buy.toJSON(),
+                sell: entry.sell.toJSON()
+            };
+        }
+
+        for (const sku in this.their) {
+            if (!Object.prototype.hasOwnProperty.call(this.their, sku)) {
+                continue;
+            }
+
+            if (itemPrices[sku] !== undefined) {
+                continue;
+            }
+
+            const entry = this.bot.pricelist.getPrice(sku, true);
+
+            itemPrices[sku] = {
+                buy: entry.buy.toJSON(),
+                sell: entry.sell.toJSON()
+            };
+        }
+
+        // Doing this so that the prices will always be displayed as only metal
+        exchange.our.scrap += exchange.our.keys * keyPrice.toValue();
+        exchange.our.keys = 0;
+        exchange.their.scrap += exchange.their.keys * keyPrice.toValue();
+        exchange.their.keys = 0;
+
+        offer.data('dict', itemsDict);
+        offer.data('value', {
+            our: {
+                total: exchange.our.value,
+                keys: exchange.our.keys,
+                metal: Currencies.toRefined(exchange.our.scrap)
+            },
+            their: {
+                total: exchange.their.value,
+                keys: exchange.their.keys,
+                metal: Currencies.toRefined(exchange.their.scrap)
+            },
+            rate: keyPrice.metal
         });
+        offer.data('prices', itemPrices);
+
+        offer.data('_dupeCheck', assetidsToCheck);
+
+        this.offer = offer;
+
+        return alteredMessages.length === 0 ? undefined : alteredMessages.join(', ');
     }
 
     // We Override the toString function so that the currencies are added

--- a/template.env
+++ b/template.env
@@ -13,6 +13,9 @@ BPTF_DETAILS_BUY="I am buying your %name% for %price%, I have %current_stock% / 
 BPTF_DETAILS_SELL="I am selling my %name% for %price%, I am selling %amount_trade%."
 OFFER_MESSAGE=""
 
+ENABLE_DUPE_CHECK=true
+DECLINE_DUPES=false
+MINIMUM_KEYS_DUPE_CHECK=10
 ENABLE_MANUAL_REVIEW=true
 AUTOBUMP=true
 


### PR DESCRIPTION
Adds dupe checks to the bot.

- Enable dupe checks by setting `ENABLE_DUPE_CHECK` to `true`. Default is `false`.
- Minimum price for dupe check can be setting `MINIMUM_KEYS_DUPE_CHECK` to any amount in keys, both whole numbers and decimals. Default is `0`.
- Decline offers that contain any duped items by setting `DECLINE_DUPES` to `true`. Default is `false`.
- If a dupe check fails then for received offers the offer will be skipped and a notification will be sent to the admins for them to review the offer, for sending offers the bot will stop and say that it failed to check for dupes.

If the bot fails to make a dupe check when creating an offer then the bot should tell the user to try and send an offer instead, that way an admin will be able to review the offer and accept / decline it.

How dupe checks work:

1. The bot attempts to get the history page of an item on backpack.tf. It will use the current assetid that the item has. If it fails then the dupe check will fail.
2. If backpack.tf knows about the item using the current assetid then the dupe check is done and the result will depend on if backpack.tf says it is duped or not.
3. If backpack.tf does not know about the item, then the bot will load the inventory using the TF2 GetPlayerItems API that backpack.tf also used to load inventories. The bot will load the inventory and find the original id. If the API does not give a good response, or the item could not be found in the inventory, then the dupe check fails.
4. The bot now has the original id and can then try and get the item history from backpack.tf using that. If it fails then we can conclude that backpack.tf doesn't know about the item, meaning that we don't know if the item is duped or not. The dupe check will fail. If backpack.tf does know about the item, then the dupe check is done.