### PR TITLE
Add plugins to ignored folders

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 local
 dist
 *.json
+# Ignore plugins, might have different configs
+plugins

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ logs/
 
 # ignore compiled code
 dist/
+
+# ignore plugins folder
+plugins/


### PR DESCRIPTION
Preemptively ignore the plugins folder, this is where things like the GUI will go in when that is done and working on VPS
It shouldn't just be installed anywhere on the VPS, as it needs a clear way of getting info like the polldata etc if there are multiple bots running (ecosystem.json)