### PR TITLE
Fix: ensure that item is intended to be bought / sold by bot

### DIFF
--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -424,7 +424,11 @@ export = class MyHandler extends Handler {
 
                     // TODO: Go through all assetids and check if the item is being sold for a specific price
 
-                    if (match !== null && (sku !== '5021;6' || !exchange.contains.items) && match.intent === (buying ? 0 : 1)) {
+                    if (
+                        match !== null &&
+                        (sku !== '5021;6' || !exchange.contains.items) &&
+                        match.intent === (buying ? 0 : 1)
+                    ) {
                         // If we found a matching price and the item is not a key, or the we are not trading items (meaning that we are trading keys) then add the price of the item
 
                         // Add value of items

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -424,17 +424,7 @@ export = class MyHandler extends Handler {
 
                     // TODO: Go through all assetids and check if the item is being sold for a specific price
 
-                    if (match === null || match.intent === (buying ? 1 : 0)) {
-                        // Offer contains an item that we are not trading
-                        hasInvalidItems = true;
-
-                        wrongAboutOffer.push({
-                            reason: 'INVALID_ITEMS',
-                            sku: sku,
-                            buying: buying,
-                            amount: amount
-                        });
-                    } else if (match !== null && (sku !== '5021;6' || !exchange.contains.items)) {
+                    if (match !== null && (sku !== '5021;6' || !exchange.contains.items)) {
                         // If we found a matching price and the item is not a key, or the we are not trading items (meaning that we are trading keys) then add the price of the item
 
                         // Add value of items
@@ -478,6 +468,16 @@ export = class MyHandler extends Handler {
                         // Offer contains keys and we are not trading keys, add key value
                         exchange[which].value += keyPrice.toValue() * amount;
                         exchange[which].keys += amount;
+                    } else if (match === null || match.intent === (buying ? 1 : 0)) {
+                        // Offer contains an item that we are not trading
+                        hasInvalidItems = true;
+
+                        wrongAboutOffer.push({
+                            reason: 'INVALID_ITEMS',
+                            sku: sku,
+                            buying: buying,
+                            amount: amount
+                        });
                     }
                 }
             }

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -424,7 +424,7 @@ export = class MyHandler extends Handler {
 
                     // TODO: Go through all assetids and check if the item is being sold for a specific price
 
-                    if (match !== null && (sku !== '5021;6' || !exchange.contains.items)) {
+                    if (match !== null && (sku !== '5021;6' || !exchange.contains.items) && match.intent === (buying ? 0 : 1)) {
                         // If we found a matching price and the item is not a key, or the we are not trading items (meaning that we are trading keys) then add the price of the item
 
                         // Add value of items

--- a/src/classes/MyHandler.ts
+++ b/src/classes/MyHandler.ts
@@ -424,7 +424,17 @@ export = class MyHandler extends Handler {
 
                     // TODO: Go through all assetids and check if the item is being sold for a specific price
 
-                    if (match !== null && (sku !== '5021;6' || !exchange.contains.items)) {
+                    if (match === null || match.intent === (buying ? 1 : 0)) {
+                        // Offer contains an item that we are not trading
+                        hasInvalidItems = true;
+
+                        wrongAboutOffer.push({
+                            reason: 'INVALID_ITEMS',
+                            sku: sku,
+                            buying: buying,
+                            amount: amount
+                        });
+                    } else if (match !== null && (sku !== '5021;6' || !exchange.contains.items)) {
                         // If we found a matching price and the item is not a key, or the we are not trading items (meaning that we are trading keys) then add the price of the item
 
                         // Add value of items
@@ -468,16 +478,6 @@ export = class MyHandler extends Handler {
                         // Offer contains keys and we are not trading keys, add key value
                         exchange[which].value += keyPrice.toValue() * amount;
                         exchange[which].keys += amount;
-                    } else if (match === null || match.intent === (buying ? 1 : 0)) {
-                        // Offer contains an item that we are not trading
-                        hasInvalidItems = true;
-
-                        wrongAboutOffer.push({
-                            reason: 'INVALID_ITEMS',
-                            sku: sku,
-                            buying: buying,
-                            amount: amount
-                        });
                     }
                 }
             }


### PR DESCRIPTION
`if (match !== null && (sku !== '5021;6' || !exchange.contains.items)) {
    ....
} else if (sku === '5021;6' && exchange.contains.items) { {
    ....
} if (match === null || match.intent === (buying ? 1 : 0)) {
    ....
}`

If a bot owner has populated their pricelist with buy and sell prices, then clearly match is non-null.

Even if the current intent of the bot to buy that item is set to the opposite of what is being performed (e.g a user sends a trade offer buying items off the bot when the bot is only buying), the first case will apply and perform item price calculating (previous lines 428 - 466) regardless, accepting if the user is able to guess the sell / buy price.

This also means that we don't 'throw' the INVALID_ITEMS error as item intent is checked after the first if statement case.

Commit is to swap the order of condition checks to make item buying/selling intent stricter.